### PR TITLE
Fixing common typos and a circular dependency issue picked up by linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This extension aims
 * to support prefix argument
 * to support sexp
 * to fix some bugs in the existing extensions such as
-    * mark-mode states are shared amoung all editors
+    * mark-mode states are shared among all editors
 
 This extension makes use of code in the existent extensions listed above and, in addition, [VSCode](https://github.com/microsoft/vscode) and [VSCode Vim extension](https://github.com/VSCodeVim/Vim). Thanks to all these great works.
 Mainly, almost all keybinding settings are derived from [vscode-emacs-friendly by Sebastian Zaha](https://github.com/SebastianZaha/vscode-emacs-friendly).

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -107,7 +107,7 @@ export class MoveBeginningOfLine extends EmacsCommand {
           select: isInMarkMode,
         });
       } else {
-        // VSCode behavior: Move to the first non-empty charactor (indentation).
+        // VSCode behavior: Move to the first non-empty character (indentation).
         return vscode.commands.executeCommand<void>(isInMarkMode ? "cursorHomeSelect" : "cursorHome");
       }
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,7 +73,7 @@ export function activate(context: vscode.ExtensionContext) {
     registerEmulatorCommand(
       "type",
       (emulator, args) => {
-        // Capture typing charactors for prefix argument functionality.
+        // Capture typing characters for prefix argument functionality.
         logger.debug(`[type command]\t args.text = "${args.text}"`);
 
         return emulator.type(args.text);

--- a/src/kill-yank/index.ts
+++ b/src/kill-yank/index.ts
@@ -2,15 +2,12 @@ import * as vscode from "vscode";
 import { Position, Range, TextEditor } from "vscode";
 import { EditorIdentity } from "../editorIdentity";
 import { MessageManager } from "../message";
-import { equalPositons } from "../utils";
+import { equalPositions } from "../utils";
 import { KillRing, KillRingEntity } from "./kill-ring";
 import { ClipboardTextKillRingEntity } from "./kill-ring-entity/clipboard-text";
-import { EditorTextKillRingEntity } from "./kill-ring-entity/editor-text";
+import { AppendDirection, EditorTextKillRingEntity } from "./kill-ring-entity/editor-text";
 
-export enum AppendDirection {
-  Forward,
-  Backward,
-}
+export { AppendDirection };
 
 export class KillYanker implements vscode.Disposable {
   private textEditor: TextEditor;
@@ -75,7 +72,7 @@ export class KillYanker implements vscode.Disposable {
   }
 
   public async kill(ranges: Range[], appendDirection: AppendDirection = AppendDirection.Forward) {
-    if (!equalPositons(this.getCursorPositions(), this.prevKillPositions)) {
+    if (!equalPositions(this.getCursorPositions(), this.prevKillPositions)) {
       this.isAppending = false;
     }
 
@@ -163,7 +160,7 @@ export class KillYanker implements vscode.Disposable {
       return;
     }
 
-    if (this.isYankInterupted()) {
+    if (this.isYankInterrupted()) {
       MessageManager.showMessage("Previous command was not a yank");
       return;
     }
@@ -204,13 +201,13 @@ export class KillYanker implements vscode.Disposable {
     return success;
   }
 
-  private isYankInterupted(): boolean {
+  private isYankInterrupted(): boolean {
     if (this.docChangedAfterYank) {
       return true;
     }
 
     const currentActives = this.getCursorPositions();
-    return !equalPositons(currentActives, this.prevYankPositions);
+    return !equalPositions(currentActives, this.prevYankPositions);
   }
 
   private getCursorPositions(): Position[] {

--- a/src/kill-yank/kill-ring-entity/editor-text.ts
+++ b/src/kill-yank/kill-ring-entity/editor-text.ts
@@ -1,8 +1,12 @@
 // tslint:disable:max-classes-per-file
 
 import { Range } from "vscode";
-import { AppendDirection } from "../";
 import { IKillRingEntity } from "./kill-ring-entity";
+
+export enum AppendDirection {
+  Forward,
+  Backward,
+}
 
 interface IRegionText {
   text: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { Position } from "vscode";
 
-export function equalPositons(positions1: Position[], positions2: Position[]): boolean {
+export function equalPositions(positions1: Position[], positions2: Position[]): boolean {
   if (positions1.length !== positions2.length) {
     return false;
   }


### PR DESCRIPTION
When importing this project our linters picked up a few typos and a circular dependency between `kill-yank/index.ts` and `kill-yank/kill-ring-entity/editor-text.ts`.