### PR TITLE
Fix newLine command test to make tabSize consistent

### DIFF
--- a/src/test/suite/commands/new-line.test.ts
+++ b/src/test/suite/commands/new-line.test.ts
@@ -107,6 +107,7 @@ suite("newLine", () => {
         test("newLine preserves the indent", async () => {
           const initialText = "()";
           activeTextEditor = await setupWorkspace(initialText, { eol });
+          activeTextEditor.options.tabSize = 4;
           emulator = new EmacsEmulator(activeTextEditor);
 
           setEmptyCursors(activeTextEditor, [0, 1]);
@@ -166,6 +167,7 @@ suite("newLine", () => {
         test("newLine preserves the indent", async () => {
           const initialText = "(a)";
           activeTextEditor = await setupWorkspace(initialText, { eol });
+          activeTextEditor.options.tabSize = 4;
           emulator = new EmacsEmulator(activeTextEditor);
 
           setEmptyCursors(activeTextEditor, [0, 2]);


### PR DESCRIPTION
Fix the unit test inconsistency reported at https://github.com/whitphx/vscode-emacs-mcx/pull/923#issuecomment-892615699