### PR TITLE
remove web extension kind

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
 		"*"
 	],
 	"extensionKind": [
-		"ui",
-		"web",
-		"workspace"
+		"ui"
 	],
 	"main": "./dist/extension.js",
 	"browser": "./dist/web/extension.js",


### PR DESCRIPTION
Hi, this is developer from VS Code. As we are rolling out web extensions we are trying to fine tune and simplify the concepts around web extensions. As a result, we are no longer supporting web as an extension kind to identify as a web extension. Instead we infer it from other properties - See https://github.com/microsoft/vscode-docs/blob/vnext/api/extension-guides/web-extensions.md#web-extension-enablement for more details. With latest vsce, it will validate extension kind for appropriate values which are `ui`, `workspace`. Since this extension has `web` extension kind, this PR fixes it properly.

It seems this extension always wants to run close to UI, so it is recommended to mark it as strict ui extension so that it will run close to UI in any environment.

Hence changed extension kind to be strict ui.