### PR TITLE
Reset active region(s) on set mark when non-empty

### DIFF
--- a/src/commands/add-selection-to-find-match.ts
+++ b/src/commands/add-selection-to-find-match.ts
@@ -6,7 +6,7 @@ export class AddSelectionToNextFindMatch extends EmacsCommand {
   public readonly id = "addSelectionToNextFindMatch";
 
   public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
-    this.emacsController.enterMarkMode();
+    this.emacsController.enterMarkMode(false);
     return vscode.commands.executeCommand<void>("editor.action.addSelectionToNextFindMatch");
   }
 }
@@ -15,7 +15,7 @@ export class AddSelectionToPreviousFindMatch extends EmacsCommand {
   public readonly id = "addSelectionToPreviousFindMatch";
 
   public execute(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
-    this.emacsController.enterMarkMode();
+    this.emacsController.enterMarkMode(false);
     return vscode.commands.executeCommand<void>("editor.action.addSelectionToPreviousFindMatch");
   }
 }

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -404,7 +404,9 @@ export class EmacsEmulator implements IEmacsCommandRunner, IMarkModeController, 
 
     if (pushMark) {
       this.pushMark(this.textEditor.selections.map((selection) => selection.active));
-      this.textEditor.selections = this.textEditor.selections.map((selection) => new Selection(selection.active, selection.active))
+      this.textEditor.selections = this.textEditor.selections.map(
+        (selection) => new Selection(selection.active, selection.active)
+      );
     }
   }
 

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -404,6 +404,7 @@ export class EmacsEmulator implements IEmacsCommandRunner, IMarkModeController, 
 
     if (pushMark) {
       this.pushMark(this.textEditor.selections.map((selection) => selection.active));
+      this.textEditor.selections = this.textEditor.selections.map((selection) => new Selection(selection.active, selection.active))
     }
   }
 

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -28,7 +28,7 @@ export interface IEmacsCommandRunner {
 }
 
 export interface IMarkModeController {
-  enterMarkMode(): void;
+  enterMarkMode(pushMark?: boolean): void;
   exitMarkMode(): void;
   pushMark(positions: vscode.Position[]): void;
 


### PR DESCRIPTION
This sets all selections to the current points when entering mark mode, basically resetting the region for each mark to empty (but leaving each empty region active). 

I don't use multi-cursor modes, so some behavior there might be unexpected, but I believe this is the expected default emacs behavior for what happens if you have a region active and set the mark (C-SPC).