### PR TITLE
Reset viewport to search start on cancel

### DIFF
--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -56,7 +56,7 @@ export class IsearchAbort extends IsearchCommand {
       textEditor.selections = this.searchState.startSelections;
     }
     MessageManager.showMessage("Quit");
-    revealPrimaryActive(textEditor)
+    revealPrimaryActive(textEditor);
     return vscode.commands.executeCommand("closeFindWidget");
   }
 }

--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -3,6 +3,7 @@ import { TextEditor } from "vscode";
 import { EmacsCommand } from ".";
 import { IEmacsCommandRunner, IMarkModeController } from "../emulator";
 import { MessageManager } from "../message";
+import { revealPrimaryActive } from "./helpers/reveal";
 
 export interface SearchState {
   startSelections: vscode.Selection[] | undefined;
@@ -55,6 +56,7 @@ export class IsearchAbort extends IsearchCommand {
       textEditor.selections = this.searchState.startSelections;
     }
     MessageManager.showMessage("Quit");
+    revealPrimaryActive(textEditor)
     return vscode.commands.executeCommand("closeFindWidget");
   }
 }


### PR DESCRIPTION
This fixes a small difference from emacs where (previously) if you cancel a search it would return the point to the place it was when the search started but would not return the viewport. This change returns the viewport to include the point.