### PR TITLE
Add a test to assert successive set-mark-command resets the region to be empty

### DIFF
--- a/src/test/suite/mark-mode.test.ts
+++ b/src/test/suite/mark-mode.test.ts
@@ -67,8 +67,7 @@ ABCDEFGHIJ`;
     emulator.setMarkCommand();
 
     // The selected region has been reset to be empty when set-mark-command was called.
-    assert.strictEqual(activeTextEditor.selections.length, 1);
-    assert.ok(activeTextEditor.selection.isEqual(new Selection(1, 2, 1, 2)));
+    assertCursorsEqual(activeTextEditor, [1, 2]);
 
     await emulator.runCommand("forwardChar");
     await emulator.runCommand("forwardChar");

--- a/src/test/suite/mark-mode.test.ts
+++ b/src/test/suite/mark-mode.test.ts
@@ -33,7 +33,6 @@ ABCDEFGHIJ`;
         ),
     ],
   ];
-
   edits.forEach(([label, editOp]) => {
     test(`exit mark-mode when ${label} occurs`, async () => {
       // Enter mark-mode and select some characters
@@ -50,6 +49,34 @@ ABCDEFGHIJ`;
       await emulator.runCommand("forwardChar");
       assert.ok(activeTextEditor.selections.every((selection) => selection.isEmpty));
     });
+  });
+
+  test("successive set-mark-command resets the region to be empty", async () => {
+    setEmptyCursors(activeTextEditor, [0, 0]);
+    emulator.setMarkCommand();
+
+    await emulator.runCommand("forwardChar");
+    await emulator.runCommand("forwardChar");
+    await emulator.runCommand("nextLine");
+
+    // The selected region has been expanded as mark-mode is enabled.
+    assert.strictEqual(activeTextEditor.selections.length, 1);
+    assert.ok(activeTextEditor.selection.isEqual(new Selection(0, 0, 1, 2)));
+
+    // set-mark-mode is called again.
+    emulator.setMarkCommand();
+
+    // The selected region has been reset to be empty when set-mark-command was called.
+    assert.strictEqual(activeTextEditor.selections.length, 1);
+    assert.ok(activeTextEditor.selection.isEqual(new Selection(1, 2, 1, 2)));
+
+    await emulator.runCommand("forwardChar");
+    await emulator.runCommand("forwardChar");
+    await emulator.runCommand("nextLine");
+
+    // Assert that mark-mode is still enabled by checking the region has been expanded.
+    assert.strictEqual(activeTextEditor.selections.length, 1);
+    assert.ok(activeTextEditor.selection.isEqual(new Selection(1, 2, 2, 4)));
   });
 });
 


### PR DESCRIPTION
Add a unit test for #1089