### PR TITLE
Upgrade Node to 16 in the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2.5.0
         with:
-          node-version: 14
+          node-version: 16
       - run: yarn install --frozen-lockfile
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v0.4.2


### PR DESCRIPTION
Necessary for HaaLeo/publish-vscode-extension v1 (#1142)