### PR TITLE
Adds next/previous buffer shortcut

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -921,6 +921,14 @@
     {
       "key": "ctrl+i",
       "command": "tab"
+    },
+    {
+      "key": "ctrl+x left",
+      "command": "workbench.action.previousEditor"
+    },
+    {
+      "key": "ctrl+x right",
+      "command": "workbench.action.nextEditor"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4681,6 +4681,14 @@
 			{
 				"key": "ctrl+i",
 				"command": "tab"
+			},
+			{
+				"key": "ctrl+x left",
+				"command": "workbench.action.previousEditor"
+			},
+			{
+				"key": "ctrl+x right",
+				"command": "workbench.action.nextEditor"
 			}
 		]
 	},


### PR DESCRIPTION
As detailed in:
https://www.gnu.org/software/emacs/manual/html_node/emacs/Select-Buffer.html

This adds shortcut keys to switch to prev & next tabs.