### PR TITLE
dev/more strict tsconfig

### DIFF
--- a/src/commands/delete-blank-lines.ts
+++ b/src/commands/delete-blank-lines.ts
@@ -13,7 +13,7 @@ export class DeleteBlankLines extends EmacsCommand {
       // therefore, each selection must be obtained
       // by indexing on each iteration.
       // That's why for-of loop is not appropriate here.
-      const selection = textEditor.selections[iSel];
+      const selection = textEditor.selections[iSel]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
       const curLineNum = selection.active.line;
       const curLine = document.lineAt(curLineNum);

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -345,10 +345,10 @@ export class ScrollUpCommand extends EmacsCommand {
     const repeat = prefixArgument === undefined ? 1 : prefixArgument;
 
     if (this.emacsController.inRectMarkMode) {
-      if (textEditor.visibleRanges.length === 0) {
+      const visibleRange = textEditor.visibleRanges[0];
+      if (visibleRange == null) {
         return;
       }
-      const visibleRange = textEditor.visibleRanges[0];
       const pageSize = Math.max(1, visibleRange.end.line - visibleRange.start.line - 2); // Ad-hoc
       const lineDelta = pageSize * repeat;
 
@@ -405,10 +405,10 @@ export class ScrollDownCommand extends EmacsCommand {
     const repeat = prefixArgument === undefined ? 1 : prefixArgument;
 
     if (this.emacsController.inRectMarkMode) {
-      if (textEditor.visibleRanges.length === 0) {
+      const visibleRange = textEditor.visibleRanges[0];
+      if (visibleRange == null) {
         return;
       }
-      const visibleRange = textEditor.visibleRanges[0];
       const pageSize = Math.max(1, visibleRange.end.line - visibleRange.start.line - 2); // Ad-hoc
       const lineDelta = pageSize * repeat;
 

--- a/src/commands/recenter.ts
+++ b/src/commands/recenter.ts
@@ -26,12 +26,17 @@ export class RecenterTopBottom extends EmacsCommand implements IEmacsCommandInte
         break;
       }
       case RecenterPosition.Bottom: {
-        // TextEditor.revealRange does not supprt to set the cursor at the bottom of window.
+        // TextEditor.revealRange does not support to set the cursor at the bottom of window.
         // Therefore, the number of lines to scroll is calculated here.
-        const current = textEditor.selection.active.line;
-        const visibleTop = textEditor.visibleRanges[0].start.line;
-        const visibleBottom = textEditor.visibleRanges[0].end.line;
+        const visibleRange = textEditor.visibleRanges[0];
+        if (visibleRange == null) {
+          return;
+        }
+        const visibleTop = visibleRange.start.line;
+        const visibleBottom = visibleRange.end.line;
         const visibleHeight = visibleBottom - visibleTop;
+
+        const current = textEditor.selection.active.line;
 
         const nextVisibleTop = Math.max(current - visibleHeight, 1);
 

--- a/src/commands/rectangle.ts
+++ b/src/commands/rectangle.ts
@@ -335,7 +335,11 @@ export class ReplaceKillRingToRectangle extends EmacsCommand {
     const lineEnd = Math.min(selection.end.line, textEditor.document.lineCount - 1);
     await textEditor.edit((edit) => {
       for (let i = lineStart; i <= lineEnd; i++) {
-        const rgn = currentRect[i - lineStart];
+        // Both `currentRect` and (`lineStart`, `lineEnd`) are calculated
+        // based on the same information from the `selection` and the `textEditor`'s range,
+        // so the `noUncheckedIndexedAccess` rule can be skipped here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const rgn = currentRect[i - lineStart]!;
         if (rgn.end.character < insertChar) {
           const fill = insertChar - rgn.end.character;
           edit.insert(new vscode.Position(i, rgn.end.character), " ".repeat(fill) + text);

--- a/src/commands/rectangle.ts
+++ b/src/commands/rectangle.ts
@@ -82,11 +82,12 @@ abstract class EditRectangle extends RectangleKillYankCommand {
     prefixArgument: number | undefined
   ): Promise<void> {
     const selections = getNonEmptySelections(textEditor);
-    if (selections.length === 0) {
+
+    const selection = selections[0]; // multi-cursor is not supported
+    if (selection == null) {
       return;
     }
 
-    const selection = selections[0]; // multi-cursor is not supported
     const notReversedSelection = new vscode.Selection(selection.start, selection.end);
 
     const rectSelections = convertSelectionToRectSelections(textEditor.document, notReversedSelection);
@@ -154,7 +155,7 @@ export class YankRectangle extends RectangleKillYankCommand {
     }
 
     const rectHeight = killedRect.length - 1;
-    const rectWidth = killedRect[rectHeight].length;
+    const rectWidth = killedRect[rectHeight]!.length; // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
     const active = textEditor.selection.active; // Multi-cursor is not supported
     await textEditor.edit((edit) => {
@@ -301,7 +302,7 @@ export class ReplaceKillRingToRectangle extends EmacsCommand {
       return;
     }
     const top = this.killring.getTop();
-    if (top === null) {
+    if (top == null) {
       return;
     }
     const text = top.asString();
@@ -311,26 +312,27 @@ export class ReplaceKillRingToRectangle extends EmacsCommand {
     }
 
     const selections = getNonEmptySelections(textEditor);
-    if (selections.length !== 1) {
-      // multiple cursor not supported
+
+    const selection = selections[0]; // multi-cursor is not supported
+    if (selection == null) {
       return;
     }
-    const insertChar = Math.min(selections[0].start.character, selections[0].end.character);
-    const finalCursorLine = selections[0].active.line;
+    const insertChar = Math.min(selection.start.character, selection.end.character);
+    const finalCursorLine = selection.active.line;
     let finalCursorChar = insertChar;
-    if (selections[0].active.character >= selections[0].anchor.character) {
+    if (selection.active.character >= selection.anchor.character) {
       finalCursorChar = insertChar + text.length;
     }
 
-    const currentRect = convertSelectionToRectSelections(textEditor.document, selections[0]);
+    const currentRect = convertSelectionToRectSelections(textEditor.document, selection);
     // rect is reversed in previous convert,
     // so we reverse it again as we need to traverse from smaller line number
-    if (selections[0].active.line < selections[0].anchor.line) {
+    if (selection.active.line < selection.anchor.line) {
       currentRect.reverse();
     }
 
-    const lineStart = Math.max(selections[0].start.line, 0);
-    const lineEnd = Math.min(selections[0].end.line, textEditor.document.lineCount - 1);
+    const lineStart = Math.max(selection.start.line, 0);
+    const lineEnd = Math.min(selection.end.line, textEditor.document.lineCount - 1);
     await textEditor.edit((edit) => {
       for (let i = lineStart; i <= lineEnd; i++) {
         const rgn = currentRect[i - lineStart];

--- a/src/commands/rectangle.ts
+++ b/src/commands/rectangle.ts
@@ -83,10 +83,11 @@ abstract class EditRectangle extends RectangleKillYankCommand {
   ): Promise<void> {
     const selections = getNonEmptySelections(textEditor);
 
-    const selection = selections[0]; // multi-cursor is not supported
-    if (selection == null) {
+    if (selections.length !== 1) {
+      // multiple cursor not supported
       return;
     }
+    const selection = selections[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
     const notReversedSelection = new vscode.Selection(selection.start, selection.end);
 
@@ -313,10 +314,12 @@ export class ReplaceKillRingToRectangle extends EmacsCommand {
 
     const selections = getNonEmptySelections(textEditor);
 
-    const selection = selections[0]; // multi-cursor is not supported
-    if (selection == null) {
+    if (selections.length !== 1) {
+      // multiple cursor not supported
       return;
     }
+    const selection = selections[0]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
     const insertChar = Math.min(selection.start.character, selection.end.character);
     const finalCursorLine = selection.active.line;
     let finalCursorChar = insertChar;

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -471,7 +471,10 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     if (prevMarks) {
       const affectedLen = Math.min(this.textEditor.selections.length, prevMarks.length);
       const affectedSelections = this.textEditor.selections.slice(0, affectedLen).map((selection, i) => {
-        const prevMark = prevMarks[i];
+        // `i < affectedLen <= prevMarks.length`,
+        // so the `noUncheckedIndexedAccess` rule can be skipped here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const prevMark = prevMarks[i]!;
         return new vscode.Selection(selection.active, prevMark);
       });
       const newSelections = affectedSelections.concat(this.textEditor.selections.slice(affectedLen));

--- a/src/kill-yank/index.ts
+++ b/src/kill-yank/index.ts
@@ -131,7 +131,10 @@ export class KillYanker implements vscode.Disposable {
             if (!selection.isEmpty) {
               editBuilder.delete(selection);
             }
-            editBuilder.insert(selection.start, regionTexts[i].getAppendedText());
+            // `regionTexts.length === selections.length` has already been checked,
+            // so noUncheckedIndexedAccess rule can be skipped here.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            editBuilder.insert(selection.start, regionTexts[i]!.getAppendedText());
           });
         });
       }
@@ -175,11 +178,11 @@ export class KillYanker implements vscode.Disposable {
     const prevKillRingEntity = this.killRing.getTop();
 
     const killRingEntity = this.killRing.popNext();
-    if (killRingEntity === null) {
+    if (killRingEntity == null) {
       return;
     }
 
-    if (prevKillRingEntity !== null && !prevKillRingEntity.isEmpty() && this.prevYankChanges > 0) {
+    if (prevKillRingEntity != null && !prevKillRingEntity.isEmpty() && this.prevYankChanges > 0) {
       for (let i = 0; i < this.prevYankChanges; ++i) {
         await vscode.commands.executeCommand("undo");
       }

--- a/src/kill-yank/kill-ring-entity/editor-text.ts
+++ b/src/kill-yank/kill-ring-entity/editor-text.ts
@@ -39,7 +39,7 @@ class AppendedRegionTexts {
   }
 
   public getLastRange(): Range {
-    return this.regionTexts[this.regionTexts.length - 1].range;
+    return this.regionTexts[this.regionTexts.length - 1]!.range; // eslint-disable-line @typescript-eslint/no-non-null-assertion
   }
 }
 
@@ -97,6 +97,11 @@ export class EditorTextKillRingEntity implements IKillRingEntity {
       throw Error("Not appendable");
     }
 
-    this.regionTextsList.map((appendedRegionTexts, i) => appendedRegionTexts.append(additional[i], appendDirection));
+    this.regionTextsList.map(
+      // `additional.length === this.regionTextsList.length` has already been checked,
+      // so noUncheckedIndexedAccess rule can be skipped here.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      (appendedRegionTexts, i) => appendedRegionTexts.append(additional[i]!, appendDirection)
+    );
   }
 }

--- a/src/kill-yank/kill-ring.ts
+++ b/src/kill-yank/kill-ring.ts
@@ -5,7 +5,7 @@ export type KillRingEntity = ClipboardTextKillRingEntity | EditorTextKillRingEnt
 
 export class KillRing {
   private maxNum = 60;
-  private killRing: KillRingEntity[];
+  private killRing: Array<KillRingEntity>;
   private pointer: number | null;
 
   constructor(maxNum = 60) {

--- a/src/kill-yank/kill-ring.ts
+++ b/src/kill-yank/kill-ring.ts
@@ -25,17 +25,17 @@ export class KillRing {
     this.pointer = 0;
   }
 
-  public getTop(): KillRingEntity | null {
+  public getTop(): KillRingEntity | undefined {
     if (this.pointer === null || this.killRing.length === 0) {
-      return null;
+      return undefined;
     }
 
     return this.killRing[this.pointer];
   }
 
-  public popNext(): KillRingEntity | null {
+  public popNext(): KillRingEntity | undefined {
     if (this.pointer === null || this.killRing.length === 0) {
-      return null;
+      return undefined;
     }
 
     this.pointer = (this.pointer + 1) % this.killRing.length;

--- a/src/mark-ring.ts
+++ b/src/mark-ring.ts
@@ -2,7 +2,7 @@ import { Position } from "vscode";
 
 export class MarkRing {
   private maxNum = 16;
-  private ring: Position[][];
+  private ring: Array<readonly Position[]>;
   private pointer: number | null;
 
   constructor(maxNum?: number) {
@@ -14,7 +14,7 @@ export class MarkRing {
     this.ring = [];
   }
 
-  public push(marks: Position[], replace = false) {
+  public push(marks: readonly Position[], replace = false) {
     if (replace) {
       this.ring[0] = marks;
     } else {
@@ -26,17 +26,17 @@ export class MarkRing {
     this.pointer = 0;
   }
 
-  public getTop(): Position[] | null {
+  public getTop(): readonly Position[] | undefined {
     if (this.pointer == null || this.ring.length === 0) {
-      return null;
+      return undefined;
     }
 
     return this.ring[this.pointer];
   }
 
-  public pop(): Position[] | null {
+  public pop(): readonly Position[] | undefined {
     if (this.pointer == null || this.ring.length === 0) {
-      return null;
+      return undefined;
     }
 
     const ret = this.ring[this.pointer];

--- a/src/platform/node/loggerImpl.ts
+++ b/src/platform/node/loggerImpl.ts
@@ -102,10 +102,14 @@ class NodeLogger implements ILogger {
   }
 
   public configChanged(configuration: IConfiguration) {
-    this.logger.transports[0].level = configuration.debug.loggingLevelForConsole;
-    this.logger.transports[0].silent = configuration.debug.silent;
-    this.logger.transports[1].level = configuration.debug.loggingLevelForAlert;
+    // `this.logger.transports` has 2 items as set at the constructor,
+    // so the `noUncheckedIndexedAccess` rule can be skipped here.
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    this.logger.transports[0]!.level = configuration.debug.loggingLevelForConsole;
+    this.logger.transports[0]!.silent = configuration.debug.silent;
+    this.logger.transports[1]!.level = configuration.debug.loggingLevelForAlert;
     (this.logger.transports[1] as VsCodeMessage).configuration = configuration;
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
   }
 }
 

--- a/src/test/suite/commands/move.test.ts
+++ b/src/test/suite/commands/move.test.ts
@@ -114,7 +114,11 @@ suite("scroll-up/down-command", () => {
     activeTextEditor = await setupWorkspace(initialText);
     emulator = new EmacsEmulator(activeTextEditor);
 
-    visibleRange = activeTextEditor.visibleRanges[0];
+    const _visibleRange = activeTextEditor.visibleRanges[0];
+    if (_visibleRange == null) {
+      throw new Error("No visible range available.");
+    }
+    visibleRange = _visibleRange;
     pageLines = visibleRange.end.line - visibleRange.start.line;
   });
 

--- a/src/test/suite/commands/paredit.test.ts
+++ b/src/test/suite/commands/paredit.test.ts
@@ -389,8 +389,7 @@ suite("paredit commands with a long text that requires revealing", () => {
 
     assert.strictEqual(activeTextEditor.selections.length, 1);
     assert.strictEqual(activeTextEditor.selection.active.line, 1000);
-    const visibleRange = activeTextEditor.visibleRanges[0];
-    assert.strictEqual(visibleRange.end.line, 1000);
+    assert.strictEqual(activeTextEditor.visibleRanges[0]?.end.line, 1000);
   });
 
   test("backwardSexp: the selection is revealed at the active cursor", async () => {
@@ -403,8 +402,7 @@ suite("paredit commands with a long text that requires revealing", () => {
 
     assert.strictEqual(activeTextEditor.selections.length, 1);
     assert.strictEqual(activeTextEditor.selection.active.line, 0);
-    const visibleRange = activeTextEditor.visibleRanges[0];
-    assert.strictEqual(visibleRange.start.line, 0);
+    assert.strictEqual(activeTextEditor.visibleRanges[0]?.start.line, 0);
   });
 });
 

--- a/src/test/suite/kill-ring.test.ts
+++ b/src/test/suite/kill-ring.test.ts
@@ -63,8 +63,8 @@ suite("KillRing", () => {
   test("zero data", () => {
     const killRing = new KillRing(3);
 
-    assert.strictEqual(killRing.getTop(), null);
-    assert.strictEqual(killRing.popNext(), null);
-    assert.strictEqual(killRing.popNext(), null);
+    assert.strictEqual(killRing.getTop(), undefined);
+    assert.strictEqual(killRing.popNext(), undefined);
+    assert.strictEqual(killRing.popNext(), undefined);
   });
 });

--- a/src/test/suite/mark-ring.test.ts
+++ b/src/test/suite/mark-ring.test.ts
@@ -88,8 +88,8 @@ suite("MarkRing", () => {
   test("zero data", () => {
     const markRing = new MarkRing(3);
 
-    assert.strictEqual(markRing.getTop(), null);
-    assert.strictEqual(markRing.pop(), null);
-    assert.strictEqual(markRing.pop(), null);
+    assert.strictEqual(markRing.getTop(), undefined);
+    assert.strictEqual(markRing.pop(), undefined);
+    assert.strictEqual(markRing.pop(), undefined);
   });
 });

--- a/src/test/suite/mark-ring.test.ts
+++ b/src/test/suite/mark-ring.test.ts
@@ -23,7 +23,7 @@ suite("MarkRing", () => {
   test("push with replace", () => {
     const markRing = new MarkRing(3);
 
-    const entities = [[new Position(0, 1)], [new Position(2, 3)], [new Position(4, 5)], [new Position(6, 7)]];
+    const entities = [[new Position(0, 1)], [new Position(2, 3)], [new Position(4, 5)], [new Position(6, 7)]] as const;
     markRing.push(entities[0], false);
     markRing.push(entities[1], false);
     markRing.push(entities[2], false);
@@ -40,7 +40,7 @@ suite("MarkRing", () => {
   test("push with replace at first", () => {
     const markRing = new MarkRing(3);
 
-    const entities = [[new Position(0, 1)], [new Position(2, 3)], [new Position(4, 5)], [new Position(6, 7)]];
+    const entities = [[new Position(0, 1)], [new Position(2, 3)], [new Position(4, 5)], [new Position(6, 7)]] as const;
     markRing.push(entities[0], true); // Replace the top
     markRing.push(entities[1], false);
     markRing.push(entities[2], false);

--- a/src/test/suite/utils.ts
+++ b/src/test/suite/utils.ts
@@ -81,7 +81,7 @@ export function assertTextEqual(textEditor: TextEditor, expectedText: string) {
 export function assertCursorsEqual(textEditor: TextEditor, ...positions: Array<[number, number]>) {
   assert.strictEqual(textEditor.selections.length, positions.length);
   textEditor.selections.forEach((selection, idx) => {
-    const pos = positions[idx];
+    const pos = positions[idx]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
     const expectedRange = new Range(new Position(pos[0], pos[1]), new Position(pos[0], pos[1]));
     assert.ok(
       selection.isEqual(expectedRange),

--- a/src/test/suite/utils.ts
+++ b/src/test/suite/utils.ts
@@ -81,6 +81,8 @@ export function assertTextEqual(textEditor: TextEditor, expectedText: string) {
 export function assertCursorsEqual(textEditor: TextEditor, ...positions: Array<[number, number]>) {
   assert.strictEqual(textEditor.selections.length, positions.length);
   textEditor.selections.forEach((selection, idx) => {
+    // `textEditor.selections.length === positions.length` has already been checked,
+    // so noUncheckedIndexedAccess rule can be skipped here.
     const pos = positions[idx]!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
     const expectedRange = new Range(new Position(pos[0], pos[1]), new Position(pos[0], pos[1]));
     assert.ok(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,5 +4,5 @@ export function equalPositions(positions1: Position[], positions2: Position[]): 
   if (positions1.length !== positions2.length) {
     return false;
   }
-  return positions1.every((p1, i) => p1.isEqual(positions2[i]));
+  return positions1.every((p1, i) => p1.isEqual(positions2[i]!)); // eslint-disable-line @typescript-eslint/no-non-null-assertion
 }

--- a/src/vs/editor/common/controller/wordCharacterClassifier.ts
+++ b/src/vs/editor/common/controller/wordCharacterClassifier.ts
@@ -33,7 +33,7 @@ function once<R>(computeFn: (input: string) => R): (input: string) => R {
 		if (!cache.hasOwnProperty(input)) {
 			cache[input] = computeFn(input);
 		}
-		return cache[input];
+		return cache[input]!;
 	};
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
 		"strict": true,   /* enable all strict type-checking options */
 		"esModuleInterop": true,
 		/* Additional Checks */
+		"noImplicitAny": true,
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
 		"esModuleInterop": true,
 		/* Additional Checks */
 		"noImplicitAny": true,
+		"noUncheckedIndexedAccess": true
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */


### PR DESCRIPTION
- Set noImplicitAny: true
- [WIP] Set noUncheckedIndexedAccess: true
- Fix paredit.test.ts for TextEditor.visibleRanges typing
- Fix src/commands/rectangle.ts
- Fix emulator.ts
- Fix src/vs/editor/common/controller/wordCharacterClassifier.ts for the TS noUncheckedIndexedAccess rule
- Fix src/platform/node/loggerImpl.ts for the TS noUncheckedIndexedAccess rule
