### PR TITLE
Paredit kill (Partial implementation)

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -905,6 +905,11 @@
       "when": "editorTextFocus"
     },
     {
+      "key": "ctrl+shift+k",
+      "command": "emacs-mcx.paredit.pareditKill",
+      "when": "editorTextFocus"
+    },
+    {
       "key": "ctrl+meta+k",
       "command": "emacs-mcx.paredit.killSexp",
       "when": "editorTextFocus"

--- a/package.json
+++ b/package.json
@@ -5001,6 +5001,11 @@
         "when": "editorTextFocus && config.emacs-mcx.useMetaPrefixCtrlLeftBracket"
       },
       {
+        "key": "ctrl+shift+k",
+        "command": "emacs-mcx.paredit.pareditKill",
+        "when": "editorTextFocus"
+      },
+      {
         "key": "ctrl+alt+k",
         "command": "emacs-mcx.paredit.killSexp",
         "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -174,6 +174,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.commandRegistry.register(new PareditCommands.MarkSexp(this));
     this.commandRegistry.register(new PareditCommands.KillSexp(this, killYanker));
     this.commandRegistry.register(new PareditCommands.BackwardKillSexp(this, killYanker));
+    this.commandRegistry.register(new PareditCommands.PareditKill(this, killYanker));
 
     this.commandRegistry.register(new AddSelectionToNextFindMatch(this));
     this.commandRegistry.register(new AddSelectionToPreviousFindMatch(this));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -335,6 +335,10 @@ export function activate(context: vscode.ExtensionContext): void {
     emulator.runCommand("paredit.killSexp");
   });
 
+  registerEmulatorCommand("emacs-mcx.paredit.pareditKill", (emulator) => {
+    emulator.runCommand("paredit.pareditKill");
+  });
+
   registerEmulatorCommand("emacs-mcx.paredit.backwardKillSexp", (emulator) => {
     emulator.runCommand("paredit.backwardKillSexp");
   });

--- a/src/test/suite/commands/paredit.test.ts
+++ b/src/test/suite/commands/paredit.test.ts
@@ -278,6 +278,139 @@ suite("paredit.backward-kill-sexp", () => {
   });
 });
 
+suite("paredit.paredit-kill kill to end-of-line", () => {
+  // https://github.com/emacsmirror/paredit/blob/d0b1a2f42fb47efc8392763d6487fd027e3a2955/paredit.el#L353
+  // ("(foo bar)|     ; Useless comment!"
+  // "(foo bar)|")
+  const initialText = "(foo bar)     ; Useless comment!";
+  let activeTextEditor: TextEditor;
+  let emulator: EmacsEmulator;
+
+  setup(async () => {
+    activeTextEditor = await setupWorkspace(initialText);
+    const killRing = new KillRing(60);
+    emulator = new EmacsEmulator(activeTextEditor, killRing);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  test("kill to end-of-line", async () => {
+    setEmptyCursors(activeTextEditor, [0, 9]);
+
+    await emulator.runCommand("paredit.pareditKill");
+
+    assertTextEqual(activeTextEditor, "(foo bar)");
+    assertCursorsEqual(activeTextEditor, [0, 9]);
+
+    await clearTextEditor(activeTextEditor);
+
+    // TODO
+    // await emulator.runCommand("yank");
+    // assertTextEqual(activeTextEditor, initialText);
+  });
+});
+
+suite("paredit.paredit-kill kill inside sexp", () => {
+  // https://github.com/emacsmirror/paredit/blob/d0b1a2f42fb47efc8392763d6487fd027e3a2955/paredit.el#L353
+  // ("(|foo bar)     ; Useful comment!"
+  // "(|)     ; Useful comment!")
+  const initialText = "(foo bar)     ; Useful comment!";
+  let activeTextEditor: TextEditor;
+  let emulator: EmacsEmulator;
+
+  setup(async () => {
+    activeTextEditor = await setupWorkspace(initialText);
+    const killRing = new KillRing(60);
+    emulator = new EmacsEmulator(activeTextEditor, killRing);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  test("kill inside sexp", async () => {
+    setEmptyCursors(activeTextEditor, [0, 1]);
+
+    await emulator.runCommand("paredit.pareditKill");
+
+    assertTextEqual(activeTextEditor, "()     ; Useful comment!");
+    assertCursorsEqual(activeTextEditor, [0, 1]);
+
+    await clearTextEditor(activeTextEditor);
+
+    // TODO
+    // await emulator.runCommand("yank");
+    // assertTextEqual(activeTextEditor, initialText);
+  });
+});
+
+suite("paredit.paredit-kill kill entire line", () => {
+  // https://github.com/emacsmirror/paredit/blob/d0b1a2f42fb47efc8392763d6487fd027e3a2955/paredit.el#L353
+  // ("|(foo bar)     ; Useless line!"
+  // "|")
+  const initialText = "(foo bar)     ; Useless line!";
+  let activeTextEditor: TextEditor;
+  let emulator: EmacsEmulator;
+
+  setup(async () => {
+    activeTextEditor = await setupWorkspace(initialText);
+    const killRing = new KillRing(60);
+    emulator = new EmacsEmulator(activeTextEditor, killRing);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  test("kill entire line", async () => {
+    setEmptyCursors(activeTextEditor, [0, 0]);
+
+    await emulator.runCommand("paredit.pareditKill");
+
+    assertTextEqual(activeTextEditor, "");
+    assertCursorsEqual(activeTextEditor, [0, 0]);
+
+    await clearTextEditor(activeTextEditor);
+
+    // TODO
+    // await emulator.runCommand("yank");
+    // assertTextEqual(activeTextEditor, initialText);
+  });
+});
+
+suite("paredit.paredit-kill kill inside string", () => {
+  // https://github.com/emacsmirror/paredit/blob/d0b1a2f42fb47efc8392763d6487fd027e3a2955/paredit.el#L353
+  // ("(foo \"|bar baz\"\n     quux)"
+  // "(foo \"|\"\n     quux)"))
+  const initialText = `(foo "bar baz"
+     quux)`;
+  let activeTextEditor: TextEditor;
+  let emulator: EmacsEmulator;
+
+  setup(async () => {
+    activeTextEditor = await setupWorkspace(initialText);
+    const killRing = new KillRing(60);
+    emulator = new EmacsEmulator(activeTextEditor, killRing);
+  });
+
+  teardown(cleanUpWorkspace);
+
+  test("kill inside string", async () => {
+    setEmptyCursors(activeTextEditor, [0, 6]);
+
+    await emulator.runCommand("paredit.pareditKill");
+
+    assertTextEqual(
+      activeTextEditor,
+      `(foo ""
+     quux)`
+    );
+    assertCursorsEqual(activeTextEditor, [0, 6]);
+
+    await clearTextEditor(activeTextEditor);
+
+    // TODO
+    // await emulator.runCommand("yank");
+    // assertTextEqual(activeTextEditor, initialText);
+  });
+});
+
 suite("paredit.mark-sexp", () => {
   const initialText = `(
   (


### PR DESCRIPTION
Hi @whitphx, thanks very much for your extension: I've been a heavy user for a couple of years now.

This is a work-in-progress PR adding `paredit-kill`. For me, for a very long time (15+ years), this has been the paredit command I've used the most. It's bound to `ctrl+k` in Emacs paredit. I use it with any language, e.g. Python, Rust, Javascript, Scala, C, Bash, etc, in addition to Emacs Lisp.

This PR isn't quite finished: it doesn't yet behave exactly as the Emacs paredit command. But I made the PR a few weeks ago, and I've been using it every day ever since. I'm opening the PR because it is already useful, and just in case anyone else wants to work with me on fixing the remaining bugs (and adding tests).

Here's the Emacs documentation for `paredit-kill`:

```
Kill a line as if with ‘kill-line’, but respecting delimiters.
In a string, act exactly as ‘kill-line’ but do not kill past the closing string delimiter.
On a line with no S-expressions on it starting after the point or within a comment, act exactly as ‘kill-line’.
Otherwise, kill all S-expressions that start after the point.
``` 

    
These screenshots show some examples of regions that would be killed by the command:

<table>
    <tbody>
        <tr>
            <td><img width="951" alt="image" src="https://user-images.githubusercontent.com/52205/194731823-10f5d722-5559-4456-8c9c-eca6d005c44e.png"></td>
        </tr>
        <tr>
            <td><img width="900" alt="image" src="https://user-images.githubusercontent.com/52205/194731828-676aa576-9fe1-4f8b-8c1a-da8477762a70.png"></td>
        </tr>
        <tr>
            <td><img width="831" alt="image" src="https://user-images.githubusercontent.com/52205/194731833-8b779ad4-3f52-4328-9bcc-13e817e6ecf4.png"></td>
        </tr>
        <tr>
            <td><img width="792" alt="image" src="https://user-images.githubusercontent.com/52205/194731865-7741f540-d43c-42bc-a5c3-fc19b7fe8b96.png"></td>
        </tr>
        <tr>
            <td><img width="956" alt="image" src="https://user-images.githubusercontent.com/52205/194731813-af0931a3-887a-421a-b7dd-e95dcf0bd53e.png"></td>
        </tr>
        <tr>
            <td><img width="956" alt="image" src="https://user-images.githubusercontent.com/52205/197050746-869073ff-5aba-41dd-9e36-c13826eff8cd.png"></td>
        </tr>
    </tbody>
  </table>

(Those screenshots were created using this commit: c2776fb967f4d2e30f2440a63a76c5a7d7f0c570)

And here are some other resources documenting and explaining the command:

http://danmidwood.com/content/2014/11/21/animated-paredit.html
https://github.com/emacsmirror/paredit/blob/d0b1a2f42fb47efc8392763d6487fd027e3a2955/paredit.el#L1409
https://github.com/emacsmirror/paredit/blob/d0b1a2f42fb47efc8392763d6487fd027e3a2955/paredit.el#L353
