### PR TITLE
Add: mark mode compatible prevBlankLine and nextBlankLine commands

### DIFF
--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -17,6 +17,8 @@ export const moveCommandIds = [
   "previousLine",
   "moveBeginningOfLine",
   "moveEndOfLine",
+  "prevBlankLine",
+  "nextBlankLine",
   "forwardWord",
   "backwardWord",
   "beginningOfBuffer",
@@ -216,6 +218,46 @@ export class MoveEndOfLine extends EmacsCommand {
         })
         .then(moveEndCommandFunc);
     }
+  }
+}
+
+export class PrevBlankLine extends EmacsCommand {
+  public readonly id = "prevBlankLine";
+
+  public execute(
+    textEditor: TextEditor,
+    isInMarkMode: boolean,
+    prefixArgument: number | undefined
+  ): void | Thenable<void> {
+    if (this.emacsController.inRectMarkMode) {
+      // TODO: not supported
+      return;
+    }
+
+    return vscode.commands.executeCommand<void>("cursorMove", {
+      to: "prevBlankLine",
+      select: isInMarkMode,
+    });
+  }
+}
+
+export class NextBlankLine extends EmacsCommand {
+  public readonly id = "nextBlankLine";
+
+  public execute(
+    textEditor: TextEditor,
+    isInMarkMode: boolean,
+    prefixArgument: number | undefined
+  ): void | Thenable<void> {
+    if (this.emacsController.inRectMarkMode) {
+      // TODO: not supported
+      return;
+    }
+
+    return vscode.commands.executeCommand<void>("cursorMove", {
+      to: "nextBlankLine",
+      select: isInMarkMode,
+    });
   }
 }
 

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -116,6 +116,8 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.commandRegistry.register(new MoveCommands.PreviousLine(this));
     this.commandRegistry.register(new MoveCommands.MoveBeginningOfLine(this));
     this.commandRegistry.register(new MoveCommands.MoveEndOfLine(this));
+    this.commandRegistry.register(new MoveCommands.PrevBlankLine(this));
+    this.commandRegistry.register(new MoveCommands.NextBlankLine(this));
     this.commandRegistry.register(new MoveCommands.ForwardWord(this));
     this.commandRegistry.register(new MoveCommands.BackwardWord(this));
     this.commandRegistry.register(new MoveCommands.BackToIndentation(this));


### PR DESCRIPTION
I've added a copy of the native vscode ```prevBlankLine``` and ```nextBlankLine``` commands, that will work together with mark mode. I've left out support for ```inRectMarkMode```, since I haven't tried using that mode within vscode yet. Though I'd be willing to look into adding that functionality later if its applicable. 