### PR TITLE
Add alternative bindings for vscode navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ You can change the key name of the prefix argument.
 - `ctrl+p` & `ctrl+e`: workbench.action.quickOpen => **Use `ctrl+x b` instead**;
 - `ctrl+p`: workbench.action.quickOpenNavigateNext => **Use `ctrl+n` instead**.
 - `ctrl+o`: workbench.action.files.openFileFolder;
+- `ctrl+left` : workbench.action.navigateBack => **Use `ctrl+shift+left` instead**;
+- `ctrl+right` : workbench.action.navigateForward => **Use `ctrl+shift+right` instead**;
 
 ## Contributions/Development
 

--- a/README.md
+++ b/README.md
@@ -382,8 +382,8 @@ You can change the key name of the prefix argument.
 - `ctrl+p` & `ctrl+e`: workbench.action.quickOpen => **Use `ctrl+x b` instead**;
 - `ctrl+p`: workbench.action.quickOpenNavigateNext => **Use `ctrl+n` instead**.
 - `ctrl+o`: workbench.action.files.openFileFolder;
-- `ctrl+left` : workbench.action.navigateBack => **Use `ctrl+shift+left` instead**;
-- `ctrl+right` : workbench.action.navigateForward => **Use `ctrl+shift+right` instead**;
+- `ctrl+left` : workbench.action.navigateBack => **Use `alt+left` instead**;
+- `ctrl+right` : workbench.action.navigateForward => **Use `alt+right` instead**;
 
 ## Contributions/Development
 

--- a/keybindings.json
+++ b/keybindings.json
@@ -174,14 +174,14 @@
       }
     },
     {
-      "keys": ["ctrl+shift+left"],
+      "keys": ["alt+left"],
       "command": "workbench.action.navigateBack",
-      "when": "editorTextFocus"
+      "when": "canNavigateBack"
     },
     {
-      "keys": ["ctrl+shift+right"],
+      "keys": ["alt+right"],
       "command": "workbench.action.navigateForward",
-      "when": "editorTextFocus"
+      "when": "canNavigateBack"
     },
     // back-to-indentation (meta + m)
     {

--- a/keybindings.json
+++ b/keybindings.json
@@ -173,6 +173,16 @@
         "then": "emacs-mcx.backwardWord"
       }
     },
+    {
+      "keys": ["ctrl+shift+left"],
+      "command": "workbench.action.navigateBack",
+      "when": "editorTextFocus"
+    },
+    {
+      "keys": ["ctrl+shift+right"],
+      "command": "workbench.action.navigateForward",
+      "when": "editorTextFocus"
+    },
     // back-to-indentation (meta + m)
     {
       "key": "meta+m",

--- a/package.json
+++ b/package.json
@@ -2406,14 +2406,14 @@
         }
       },
       {
-        "key": "ctrl+shift+left",
+        "key": "alt+left",
         "command": "workbench.action.navigateBack",
-        "when": "editorTextFocus"
+        "when": "canNavigateBack"
       },
       {
-        "key": "ctrl+shift+right",
+        "key": "alt+right",
         "command": "workbench.action.navigateForward",
-        "when": "editorTextFocus"
+        "when": "canNavigateBack"
       },
       {
         "key": "alt+m",

--- a/package.json
+++ b/package.json
@@ -2406,6 +2406,16 @@
         }
       },
       {
+        "key": "ctrl+shift+left",
+        "command": "workbench.action.navigateBack",
+        "when": "editorTextFocus"
+      },
+      {
+        "key": "ctrl+shift+right",
+        "command": "workbench.action.navigateForward",
+        "when": "editorTextFocus"
+      },
+      {
         "key": "alt+m",
         "command": "emacs-mcx.backToIndentation",
         "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"


### PR DESCRIPTION
#775 

vscode default bindings:
```
  { "key": "ctrl+left", "command": "workbench.action.navigateBack" },
  { "key": "ctrl+right", "command": "workbench.action.navigateForward" }
```
conflicts with the extension.

alternative bindings added:
```
    {
      "keys": ["ctrl+shift+left"],
      "command": "workbench.action.navigateBack",
      "when": "editorTextFocus"
    },
    {
      "keys": ["ctrl+shift+right"],
      "command": "workbench.action.navigateForward",
      "when": "editorTextFocus"
    },
```

I tried to propose ctrl+- and ctrl++ or ctrl+_, but on windows ctrl+_ and ctrl++ are for zoom in and out. They are somehow captured before vscode keybindings, and does not work. So the ctrl+shift+left in this PR is proposed and tested.
Let me know if you have better suggestions for alternative bindings.