### PR TITLE
Assign `ctrl+s` and `ctrl+r` to the `notebook.find` command

### DIFF
--- a/keybindings.json
+++ b/keybindings.json
@@ -316,6 +316,13 @@
       "command": "editor.action.previousMatchFindAction",
       "when": "findInputFocussed"
     },
+    // On notebooks, only `notebook.find` is available so we can't use Emacs-like i-search.
+    // As a fallback, we use `notebook.find` for `ctrl+s` and `ctrl+r`.
+    {
+      "keys": ["ctrl+s", "ctrl+r"],
+      "command": "notebook.find",
+      "when": "notebookEditorFocused && activeEditor == 'workbench.editor.interactive' || notebookEditorFocused && activeEditor == 'workbench.editor.notebook'"
+    },
     // i-search forward regexp
     {
       "key": "ctrl+meta+s",

--- a/package.json
+++ b/package.json
@@ -2848,6 +2848,16 @@
         "when": "findInputFocussed"
       },
       {
+        "key": "ctrl+s",
+        "command": "notebook.find",
+        "when": "notebookEditorFocused && activeEditor == 'workbench.editor.interactive' || notebookEditorFocused && activeEditor == 'workbench.editor.notebook'"
+      },
+      {
+        "key": "ctrl+r",
+        "command": "notebook.find",
+        "when": "notebookEditorFocused && activeEditor == 'workbench.editor.interactive' || notebookEditorFocused && activeEditor == 'workbench.editor.notebook'"
+      },
+      {
         "key": "ctrl+alt+s",
         "command": "emacs-mcx.isearchForwardRegexp",
         "when": "!findInputFocussed && !config.emacs-mcx.useMetaPrefixMacCmd"


### PR DESCRIPTION
For #1534, while this is not a complete solution for it.