### PR TITLE
fix/text switch

### DIFF
--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -240,7 +240,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     // For example when the active text editor is switched by the code jump feature,
     // the selections are overridden by the code jump result AFTER `onDidChangeActiveTextEditor` is invoked
     // with some delay. So we need to wait for the selection change.
-    // XXX: The delay time is determined in an ad-hoc manner.
+    // XXX: This delay time is ad-hoc.
     await this.waitNativeSelectionsSet(100);
 
     this.setNativeSelections(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,9 +49,13 @@ export function activate(context: vscode.ExtensionContext): void {
       const [curEmulator, isNew] = emulatorMap.getOrCreate(editor);
       if (isNew) {
         context.subscriptions.push(curEmulator);
+      } else {
+        // NOTE: `switchTextEditor()`'s behavior is flaky
+        // as it depends on a delay with an ad-hoc duration,
+        // so it's important to put this call at this else block
+        // and avoid calling it when it's not necessary.
+        curEmulator.switchTextEditor(editor);
       }
-
-      curEmulator.switchTextEditor(editor);
     }),
   );
 


### PR DESCRIPTION
- Fix to call `Emulator.switchTextEditor()` only when necessary
- Fix a comment
