### PR TITLE
dev/refactor text editor interrupt handler

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -31,12 +31,12 @@ export abstract class EmacsCommand {
   public onDidInterruptTextEditor?(): void;
 }
 
-export interface IEmacsCommandInterrupted {
+export interface ITextEditorInterruptionHandler {
   onDidInterruptTextEditor(): void;
 }
 
-export function instanceOfIEmacsCommandInterrupted<T extends { onDidInterruptTextEditor?: unknown }>(
+export function isTextEditorInterruptionHandler<T extends { onDidInterruptTextEditor?: unknown }>(
   obj: T,
-): obj is T & IEmacsCommandInterrupted {
+): obj is T & ITextEditorInterruptionHandler {
   return typeof obj.onDidInterruptTextEditor === "function";
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,12 +27,16 @@ export abstract class EmacsCommand {
     isInMarkMode: boolean,
     prefixArgument: number | undefined,
   ): void | Thenable<unknown>;
+
+  public onDidInterruptTextEditor?(): void;
 }
 
 export interface IEmacsCommandInterrupted {
   onDidInterruptTextEditor(): void;
 }
 
-export function instanceOfIEmacsCommandInterrupted(obj: any): obj is IEmacsCommandInterrupted {
+export function instanceOfIEmacsCommandInterrupted<T extends { onDidInterruptTextEditor?: unknown }>(
+  obj: T,
+): obj is T & IEmacsCommandInterrupted {
   return typeof obj.onDidInterruptTextEditor === "function";
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -35,6 +35,7 @@ export interface ITextEditorInterruptionHandler {
   onDidInterruptTextEditor(): void;
 }
 
+// This type guard trick is from https://stackoverflow.com/a/64163454/13103190
 export function isTextEditorInterruptionHandler<T extends { onDidInterruptTextEditor?: unknown }>(
   obj: T,
 ): obj is T & ITextEditorInterruptionHandler {

--- a/src/commands/recenter.ts
+++ b/src/commands/recenter.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { TextEditor, TextEditorRevealType } from "vscode";
-import { EmacsCommand, IEmacsCommandInterrupted } from ".";
+import { EmacsCommand, ITextEditorInterruptionHandler } from ".";
 
 enum RecenterPosition {
   Middle,
@@ -8,7 +8,7 @@ enum RecenterPosition {
   Bottom,
 }
 
-export class RecenterTopBottom extends EmacsCommand implements IEmacsCommandInterrupted {
+export class RecenterTopBottom extends EmacsCommand implements ITextEditorInterruptionHandler {
   public readonly id = "recenterTopBottom";
 
   private recenterPosition: RecenterPosition = RecenterPosition.Middle;

--- a/src/commands/rectangle.ts
+++ b/src/commands/rectangle.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { TextEditor } from "vscode";
-import { EmacsCommand, IEmacsCommandInterrupted } from ".";
+import { EmacsCommand, ITextEditorInterruptionHandler } from ".";
 import { IEmacsController } from "../emulator";
 import { getNonEmptySelections, makeSelectionsEmpty } from "./helpers/selection";
 import { convertSelectionToRectSelections } from "../rectangle";
@@ -16,7 +16,7 @@ import { Minibuffer } from "src/minibuffer";
  * with `{ "when": "emacs-mcx.acceptingRectCommand" }` condition.
  * Then, `kill-rectangle` can be executed through `C-x r k`.
  */
-export class StartAcceptingRectCommand extends EmacsCommand implements IEmacsCommandInterrupted {
+export class StartAcceptingRectCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
   public readonly id = "startAcceptingRectCommand";
 
   private acceptingRectCommand = false;

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { EmacsCommand, IEmacsCommandInterrupted } from ".";
+import { EmacsCommand, ITextEditorInterruptionHandler } from ".";
 
 // Will bind this this to C-x r s
-export class StartRegisterSaveCommand extends EmacsCommand implements IEmacsCommandInterrupted {
+export class StartRegisterSaveCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
   public readonly id = "StartRegisterSaveCommand";
 
   private acceptingRegisterSaveCommand = false;
@@ -30,7 +30,7 @@ export class StartRegisterSaveCommand extends EmacsCommand implements IEmacsComm
 }
 
 // Will bind this this to C-x r i
-export class StartRegisterInsertCommand extends EmacsCommand implements IEmacsCommandInterrupted {
+export class StartRegisterInsertCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
   public readonly id = "StartRegisterInsertCommand";
 
   private acceptingRegisterInsertCommand = false;

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -191,7 +191,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.commandRegistry.register(new KillCommands.CopyRegion(this, killYanker));
     this.commandRegistry.register(new KillCommands.Yank(this, killYanker));
     this.commandRegistry.register(new KillCommands.YankPop(this, killYanker));
-    this.killYanker = killYanker; // TODO: To be removed
+    this.killYanker = killYanker;
     this.registerDisposable(killYanker);
 
     this.commandRegistry.register(new StartRegisterSaveCommand(this));

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Selection, TextEditor } from "vscode";
-import { instanceOfIEmacsCommandInterrupted } from "./commands";
+import { isTextEditorInterruptionHandler } from "./commands";
 import { AddSelectionToNextFindMatch, AddSelectionToPreviousFindMatch } from "./commands/add-selection-to-find-match";
 import * as CaseCommands from "./commands/case";
 import { DeleteBlankLines } from "./commands/delete-blank-lines";
@@ -614,7 +614,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
 
   private onDidInterruptTextEditor() {
     this.commandRegistry.forEach((command) => {
-      if (instanceOfIEmacsCommandInterrupted(command)) {
+      if (isTextEditorInterruptionHandler(command)) {
         // TODO: Cache the array of IEmacsCommandInterrupted instances
         command.onDidInterruptTextEditor();
       }


### PR DESCRIPTION
- Refactor `IEmacsCommandInterrupted` type guard
- Rename `IEmacsCommandInterrupted` to `ITextEditorInterruptionHandler`
