### PR TITLE
Emacs variable line-move-visual feature implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Note that this config makes use of VSCode API's `type` command under the hood an
 Indicates whether `M-<digit>` (the `emacs-mcx.digitArgument` command) is enabled.
 Set `false` when `M-<digit>` conflicts with some other necessary commands. See https://github.com/whitphx/vscode-emacs-mcx/issues/1208 for the background.
 
+### `emacs-mcx.lineMoveVisual`
+
+When true, line-move moves point by visual lines (same as an Emacs variable line-move-visual).
+
 ### `emacs-mcx.debug.*`
 
 Configurations for debugging.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emacs-mcx",
   "displayName": "Awesome Emacs Keymap",
-  "description": "DrScKAWAMOTO version (Emacs Friendly Keymap with multi cursor support, improved mark-mode experience, clipboard and kill-ring integration, and lots of improvements and bug fixes.)",
+  "description": "Emacs Friendly Keymap with multi cursor support, improved mark-mode experience, clipboard and kill-ring integration, and lots of improvements and bug fixes.",
   "version": "0.52.1",
   "publisher": "tuttieee",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emacs-mcx",
   "displayName": "Awesome Emacs Keymap",
-  "description": "Emacs Friendly Keymap with multi cursor support, improved mark-mode experience, clipboard and kill-ring integration, and lots of improvements and bug fixes.",
+  "description": "DrScKAWAMOTO version (Emacs Friendly Keymap with multi cursor support, improved mark-mode experience, clipboard and kill-ring integration, and lots of improvements and bug fixes.)",
   "version": "0.52.1",
   "publisher": "tuttieee",
   "repository": {
@@ -91,6 +91,11 @@
           "type": "boolean",
           "default": true,
           "description": "Whether M-<digit> (the `emacs-mcx.digitArgument` command) is enabled."
+        },
+        "emacs-mcx.lineMoveVisual": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, line-move moves point by visual lines (same as an Emacs variable line-move-visual)."
         },
         "emacs-mcx.debug.silent": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         },
         "emacs-mcx.lineMoveVisual": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "When true, line-move moves point by visual lines (same as an Emacs variable line-move-visual)."
         },
         "emacs-mcx.debug.silent": {

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -99,7 +99,7 @@ export class NextLine extends EmacsCommand {
 
     return vscode.commands.executeCommand<void>("cursorMove", {
       to: "down",
-      by: "wrappedLine",
+      by: Configuration.instance.lineMoveVisual ? "wrappedLine" : "line",
       value: lineDelta,
       select: isInMarkMode,
     });
@@ -121,7 +121,7 @@ export class PreviousLine extends EmacsCommand {
 
     return vscode.commands.executeCommand<void>("cursorMove", {
       to: "up",
-      by: "wrappedLine",
+      by: Configuration.instance.lineMoveVisual ? "wrappedLine" : "line",
       value: lineDelta,
       select: isInMarkMode,
     });
@@ -344,7 +344,7 @@ export class ScrollUpCommand extends EmacsCommand {
       return vscode.commands
         .executeCommand<void>("editorScroll", {
           to: "down",
-          by: "wrappedLine",
+          by: Configuration.instance.lineMoveVisual ? "wrappedLine" : "line",
           value: prefixArgument,
         })
         .then(() => movePrimaryCursorIntoVisibleRange(textEditor, isInMarkMode, this.emacsController));
@@ -371,7 +371,7 @@ export class ScrollDownCommand extends EmacsCommand {
       return vscode.commands
         .executeCommand<void>("editorScroll", {
           to: "up",
-          by: "wrappedLine",
+          by: Configuration.instance.lineMoveVisual ? "wrappedLine" : "line",
           value: prefixArgument,
         })
         .then(() => movePrimaryCursorIntoVisibleRange(textEditor, isInMarkMode, this.emacsController));

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -38,6 +38,8 @@ export class Configuration implements IConfiguration, vscode.Disposable {
 
   public enableOverridingTypeCommand = false;
 
+  public lineMoveVisual = false;
+
   public debug: IDebugConfiguration = {
     silent: false,
     loggingLevelForAlert: "error",

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -38,7 +38,7 @@ export class Configuration implements IConfiguration, vscode.Disposable {
 
   public enableOverridingTypeCommand = false;
 
-  public lineMoveVisual = false;
+  public lineMoveVisual = true;
 
   public debug: IDebugConfiguration = {
     silent: false,

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -35,6 +35,11 @@ export interface IConfiguration {
   enableOverridingTypeCommand: boolean;
 
   /**
+   * When true, line-move moves point by visual lines (same as an Emacs variable line-move-visual).
+   */
+  lineMoveVisual: boolean;
+
+  /**
    * Extension debugging settings
    */
   debug: IDebugConfiguration;


### PR DESCRIPTION
Hi.

I had implemented Emacs variable line-move-visual feature.
This feature affects NextLine, PreviousLine, ScrollUpCommand, and ScrollDownCommand classes. 
If lineMoveVisual setting is set to true, then these classes act compatible with whitphx/vscode-emacs-mcx.
If lineMoveVisual settting is set to false, then these classes act as if logical lines.
So we can use emacs keyboard macro precisely, which is implemented by Keyboard Macro Beta extension (https://github.com/tshino/vscode-kb-macro) and Awesome Emacs Keymap wrapper
(https://github.com/tshino/vscode-kb-macro/blob/main/keymap-wrapper/tuttieee.emacs-mcx.json).
The default lineMoveVisual setting is true.

Thanx.
