### PR TITLE
Override the default value of `editor.find.seedSearchStringFromSelection` via the `configurationDefaults` contribution point

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,6 @@ It's an intended design that simulates the original Emacs' behavior.
 You can disable it with `emacs-mcx.cursorMoveOnFindWidget` option described below.
 See https://github.com/whitphx/vscode-emacs-mcx/issues/137 for the details about this topic.
 
-### i-search (`C-s`) is initialized with the currently selected string and the previous search is removed.
-
-This is VSCode's design that an extension cannot control.
-To disable it, you should set `editor.find.seedSearchStringFromSelection` VSCode setting as `"never"`.
-It makes the find widget work similarly to Emacs.
-
-Refs:
-
-- [The official doc about `editor.find.seedSearchStringFromSelection` setting](basics#_seed-search-string-from-selection)
-- [The GitHub issue where we discuss about it](https://github.com/whitphx/vscode-emacs-mcx/issues/107)
-
 ### The extension has been broken!
 
 Try the `Developer: Reinstall Extension...` command from the command palette to reinstall the extension. I fixed [a problem](https://github.com/whitphx/vscode-emacs-mcx/issues/1654) by this way somehow.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ It's an intended design that simulates the original Emacs' behavior.
 You can disable it with `emacs-mcx.cursorMoveOnFindWidget` option described below.
 See https://github.com/whitphx/vscode-emacs-mcx/issues/137 for the details about this topic.
 
+### The find widget is not initialized with the currently selected string when using `C-s`. It's different from the original VSCode' behavior.
+
+This behavior is controlled by `editor.find.seedSearchStringFromSelection` VSCode setting. This extension overrides its default value as `"never"` for the Emacs-like behavior,
+while the original VSCode's default value is `"always"`.
+
+You can [edit the setting](https://code.visualstudio.com/docs/getstarted/settings) if you prefer a different behavior.
+
 ### The extension has been broken!
 
 Try the `Developer: Reinstall Extension...` command from the command palette to reinstall the extension. I fixed [a problem](https://github.com/whitphx/vscode-emacs-mcx/issues/1654) by this way somehow.

--- a/package.json
+++ b/package.json
@@ -130,6 +130,9 @@
         }
       }
     },
+    "configurationDefaults": {
+      "editor.find.seedSearchStringFromSelection": "never"
+    },
     "commands": [
       {
         "command": "emacs-mcx.addSelectionToNextFindMatch",


### PR DESCRIPTION
`configurationDefaults` can override even the default value of other registered config.

https://github.com/microsoft/vscode-docs/blob/32c13b36b370c1e579888a7e5a6d5cc7e8e7b5ff/release-notes/v1_63.md?plain=1#L499

This feature is available since 1.63, so we don't have to update the `engines` field of the `package.json` of this extension.

Resolves #107