### PR TITLE
Revert "Override the default value of `editor.find.seedSearchStringFromSelection` via the `configurationDefaults` contribution point"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,16 @@ It's an intended design that simulates the original Emacs' behavior.
 You can disable it with `emacs-mcx.cursorMoveOnFindWidget` option described below.
 See https://github.com/whitphx/vscode-emacs-mcx/issues/137 for the details about this topic.
 
-### The find widget is not initialized with the currently selected string when using `C-s`. It's different from the original VSCode' behavior.
+### i-search (`C-s`) is initialized with the currently selected string and the previous search is removed.
 
-This behavior is controlled by `editor.find.seedSearchStringFromSelection` VSCode setting. This extension overrides its default value as `"never"` for the Emacs-like behavior,
-while the original VSCode's default value is `"always"`.
+This is VSCode's design that an extension cannot control.
+To disable it, you should set `editor.find.seedSearchStringFromSelection` VSCode setting as `"never"`.
+It makes the find widget work similarly to Emacs.
 
-You can [edit the setting](https://code.visualstudio.com/docs/getstarted/settings) if you prefer a different behavior.
+Refs:
+
+- [The official doc about `editor.find.seedSearchStringFromSelection` setting](basics#_seed-search-string-from-selection)
+- [The GitHub issue where we discuss about it](https://github.com/whitphx/vscode-emacs-mcx/issues/107)
 
 ### The extension has been broken!
 

--- a/package.json
+++ b/package.json
@@ -130,9 +130,6 @@
         }
       }
     },
-    "configurationDefaults": {
-      "editor.find.seedSearchStringFromSelection": "never"
-    },
     "commands": [
       {
         "command": "emacs-mcx.addSelectionToNextFindMatch",


### PR DESCRIPTION
Reverts whitphx/vscode-emacs-mcx#1766

Supports #1767

Overwriting `editor.find.seedSearchStringFromSelection` affects not only `C-s` but also the built-in `cmd-f`, which is too aggressive according to the policy #1767 .
-> Introducing a custom config only affecting `C-s` may be a good middle-way solution