### PR TITLE
Fix the scroll-(up|down)-command tests

### DIFF
--- a/src/test/suite/commands/move.test.ts
+++ b/src/test/suite/commands/move.test.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import assert from "assert";
+import sinon from "sinon";
 import { Range, TextEditor } from "vscode";
 import { EmacsEmulator } from "../../../emulator";
 import { assertCursorsEqual, assertSelectionsEqual, setEmptyCursors, setupWorkspace, cleanUpWorkspace } from "../utils";
@@ -232,16 +233,18 @@ suite("scroll-up/down-command", () => {
     visibleRange = _visibleRange;
     pageLines = visibleRange.end.line - visibleRange.start.line;
   });
-  teardown(cleanUpWorkspace);
+  teardown(async () => {
+    sinon.restore();
+    await cleanUpWorkspace();
+  });
 
   suite("scroll-up-command", () => {
-    test("it scrolls one page and moves the cursor to the bottom of the visible range", async () => {
-      const middleVisibleLine = Math.floor((visibleRange.start.line + visibleRange.end.line) / 2);
-      setEmptyCursors(activeTextEditor, [middleVisibleLine, 0]);
-
+    test("it delegates to the cursorPageDown command", async () => {
+      sinon.spy(vscode.commands, "executeCommand");
       await emulator.runCommand("scrollUpCommand");
-
-      assertCursorsEqual(activeTextEditor, [(activeTextEditor.visibleRanges[0]?.end.line as number) - 1, 0]);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      assert(vscode.commands.executeCommand.calledWithExactly("cursorPageDown"), "cursorPageDown is not called");
     });
 
     test("it scrolls one page if the cursor remains in the visible range without cursor move with strictEmacsMove = true", async () => {
@@ -300,13 +303,12 @@ suite("scroll-up/down-command", () => {
   });
 
   suite("scroll-down-command", () => {
-    test("it scrolls one page and moves the cursor to the top of the visible range", async () => {
-      const middleVisibleLine = Math.floor((visibleRange.start.line + visibleRange.end.line) / 2);
-      setEmptyCursors(activeTextEditor, [middleVisibleLine, 0]);
-
+    test("it delegates to the cursorPageUp command", async () => {
+      sinon.spy(vscode.commands, "executeCommand");
       await emulator.runCommand("scrollDownCommand");
-
-      assertCursorsEqual(activeTextEditor, [activeTextEditor.visibleRanges[0]?.start.line as number, 0]);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      assert(vscode.commands.executeCommand.calledWithExactly("cursorPageUp"), "cursorPageUp is not called");
     });
 
     test("it scrolls one page without cursor move if the cursor remains in the visible range with strictEmacsMove = true", async () => {

--- a/src/test/suite/commands/move.test.ts
+++ b/src/test/suite/commands/move.test.ts
@@ -245,6 +245,7 @@ suite("scroll-up/down-command", () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       assert(vscode.commands.executeCommand.calledWithExactly("cursorPageDown"), "cursorPageDown is not called");
+      sinon.restore();
     });
 
     test("it scrolls one page if the cursor remains in the visible range without cursor move with strictEmacsMove = true", async () => {
@@ -309,6 +310,7 @@ suite("scroll-up/down-command", () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       assert(vscode.commands.executeCommand.calledWithExactly("cursorPageUp"), "cursorPageUp is not called");
+      sinon.restore();
     });
 
     test("it scrolls one page without cursor move if the cursor remains in the visible range with strictEmacsMove = true", async () => {


### PR DESCRIPTION
* `cursorPageDown` command's behavior has been changed in the current ver. of VSCode Web, so the test started to fail.
* These test cases don't have to check the cursor movements precisely. Instead, checking the internally called command is enough.