### PR TITLE
dev/refactoring register commands

### DIFF
--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -312,8 +312,8 @@ export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
     keybindings.push({
       key: char,
       when: "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-      command: "emacs-mcx.RegisterSaveCommand",
-      args: [char],
+      command: "emacs-mcx.copyToRegister",
+      args: char,
     });
   }
 
@@ -321,8 +321,8 @@ export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
     keybindings.push({
       key: char,
       when: "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-      command: "emacs-mcx.RegisterInsertCommand",
-      args: [char],
+      command: "emacs-mcx.insertRegister",
+      args: char,
     });
   }
   return keybindings;

--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -311,7 +311,7 @@ export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
   for (const char of asciiPrintableChars) {
     keybindings.push({
       key: char,
-      when: "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+      when: "emacs-mcx.inRegisterCopyMode && editorTextFocus",
       command: "emacs-mcx.copyToRegister",
       args: char,
     });

--- a/keybindings.json
+++ b/keybindings.json
@@ -758,12 +758,12 @@
     },
     {
       "key": "s", // ctrl+x r s
-      "command": "emacs-mcx.StartRegisterSaveCommand",
+      "command": "emacs-mcx.startRegisterCopyCommand",
       "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "key": "i", // ctrl+x r i
-      "command": "emacs-mcx.StartRegisterInsertCommand",
+      "command": "emacs-mcx.startRegisterInsertCommand",
       "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {

--- a/package.json
+++ b/package.json
@@ -4010,1522 +4010,1142 @@
       {
         "key": " ",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          " "
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": " "
       },
       {
         "key": "!",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "!"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "!"
       },
       {
         "key": "\"",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "\""
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "\""
       },
       {
         "key": "#",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "#"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "#"
       },
       {
         "key": "$",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "$"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "$"
       },
       {
         "key": "%",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "%"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "%"
       },
       {
         "key": "&",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "&"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "&"
       },
       {
         "key": "'",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "'"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "'"
       },
       {
         "key": "(",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "("
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "("
       },
       {
         "key": ")",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          ")"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": ")"
       },
       {
         "key": "*",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "*"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "*"
       },
       {
         "key": "+",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "+"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "+"
       },
       {
         "key": ",",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          ","
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": ","
       },
       {
         "key": "-",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "-"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "-"
       },
       {
         "key": ".",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "."
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "."
       },
       {
         "key": "/",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "/"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "/"
       },
       {
         "key": "0",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "0"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "0"
       },
       {
         "key": "1",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "1"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "1"
       },
       {
         "key": "2",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "2"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "2"
       },
       {
         "key": "3",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "3"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "3"
       },
       {
         "key": "4",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "4"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "4"
       },
       {
         "key": "5",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "5"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "5"
       },
       {
         "key": "6",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "6"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "6"
       },
       {
         "key": "7",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "7"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "7"
       },
       {
         "key": "8",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "8"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "8"
       },
       {
         "key": "9",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "9"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "9"
       },
       {
         "key": ":",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          ":"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": ":"
       },
       {
         "key": ";",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          ";"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": ";"
       },
       {
         "key": "<",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "<"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "<"
       },
       {
         "key": "=",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "="
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "="
       },
       {
         "key": ">",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          ">"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": ">"
       },
       {
         "key": "?",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "?"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "?"
       },
       {
         "key": "@",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "@"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "@"
       },
       {
         "key": "A",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "A"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "A"
       },
       {
         "key": "B",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "B"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "B"
       },
       {
         "key": "C",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "C"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "C"
       },
       {
         "key": "D",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "D"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "D"
       },
       {
         "key": "E",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "E"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "E"
       },
       {
         "key": "F",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "F"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "F"
       },
       {
         "key": "G",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "G"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "G"
       },
       {
         "key": "H",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "H"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "H"
       },
       {
         "key": "I",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "I"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "I"
       },
       {
         "key": "J",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "J"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "J"
       },
       {
         "key": "K",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "K"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "K"
       },
       {
         "key": "L",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "L"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "L"
       },
       {
         "key": "M",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "M"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "M"
       },
       {
         "key": "N",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "N"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "N"
       },
       {
         "key": "O",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "O"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "O"
       },
       {
         "key": "P",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "P"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "P"
       },
       {
         "key": "Q",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "Q"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "Q"
       },
       {
         "key": "R",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "R"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "R"
       },
       {
         "key": "S",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "S"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "S"
       },
       {
         "key": "T",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "T"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "T"
       },
       {
         "key": "U",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "U"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "U"
       },
       {
         "key": "V",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "V"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "V"
       },
       {
         "key": "W",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "W"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "W"
       },
       {
         "key": "X",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "X"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "X"
       },
       {
         "key": "Y",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "Y"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "Y"
       },
       {
         "key": "Z",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "Z"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "Z"
       },
       {
         "key": "[",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "["
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "["
       },
       {
         "key": "\\",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "\\"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "\\"
       },
       {
         "key": "]",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "]"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "]"
       },
       {
         "key": "^",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "^"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "^"
       },
       {
         "key": "_",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "_"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "_"
       },
       {
         "key": "`",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "`"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "`"
       },
       {
         "key": "a",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "a"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "a"
       },
       {
         "key": "b",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "b"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "b"
       },
       {
         "key": "c",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "c"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "c"
       },
       {
         "key": "d",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "d"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "d"
       },
       {
         "key": "e",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "e"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "e"
       },
       {
         "key": "f",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "f"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "f"
       },
       {
         "key": "g",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "g"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "g"
       },
       {
         "key": "h",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "h"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "h"
       },
       {
         "key": "i",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "i"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "i"
       },
       {
         "key": "j",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "j"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "j"
       },
       {
         "key": "k",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "k"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "k"
       },
       {
         "key": "l",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "l"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "l"
       },
       {
         "key": "m",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "m"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "m"
       },
       {
         "key": "n",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "n"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "n"
       },
       {
         "key": "o",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "o"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "o"
       },
       {
         "key": "p",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "p"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "p"
       },
       {
         "key": "q",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "q"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "q"
       },
       {
         "key": "r",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "r"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "r"
       },
       {
         "key": "s",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "s"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "s"
       },
       {
         "key": "t",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "t"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "t"
       },
       {
         "key": "u",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "u"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "u"
       },
       {
         "key": "v",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "v"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "v"
       },
       {
         "key": "w",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "w"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "w"
       },
       {
         "key": "x",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "x"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "x"
       },
       {
         "key": "y",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "y"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "y"
       },
       {
         "key": "z",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "z"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "z"
       },
       {
         "key": "{",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "{"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "{"
       },
       {
         "key": "|",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "|"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "|"
       },
       {
         "key": "}",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "}"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "}"
       },
       {
         "key": "~",
         "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterSaveCommand",
-        "args": [
-          "~"
-        ]
+        "command": "emacs-mcx.copyToRegister",
+        "args": "~"
       },
       {
         "key": " ",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          " "
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": " "
       },
       {
         "key": "!",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "!"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "!"
       },
       {
         "key": "\"",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "\""
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "\""
       },
       {
         "key": "#",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "#"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "#"
       },
       {
         "key": "$",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "$"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "$"
       },
       {
         "key": "%",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "%"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "%"
       },
       {
         "key": "&",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "&"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "&"
       },
       {
         "key": "'",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "'"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "'"
       },
       {
         "key": "(",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "("
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "("
       },
       {
         "key": ")",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          ")"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": ")"
       },
       {
         "key": "*",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "*"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "*"
       },
       {
         "key": "+",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "+"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "+"
       },
       {
         "key": ",",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          ","
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": ","
       },
       {
         "key": "-",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "-"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "-"
       },
       {
         "key": ".",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "."
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "."
       },
       {
         "key": "/",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "/"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "/"
       },
       {
         "key": "0",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "0"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "0"
       },
       {
         "key": "1",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "1"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "1"
       },
       {
         "key": "2",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "2"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "2"
       },
       {
         "key": "3",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "3"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "3"
       },
       {
         "key": "4",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "4"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "4"
       },
       {
         "key": "5",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "5"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "5"
       },
       {
         "key": "6",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "6"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "6"
       },
       {
         "key": "7",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "7"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "7"
       },
       {
         "key": "8",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "8"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "8"
       },
       {
         "key": "9",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "9"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "9"
       },
       {
         "key": ":",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          ":"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": ":"
       },
       {
         "key": ";",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          ";"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": ";"
       },
       {
         "key": "<",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "<"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "<"
       },
       {
         "key": "=",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "="
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "="
       },
       {
         "key": ">",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          ">"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": ">"
       },
       {
         "key": "?",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "?"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "?"
       },
       {
         "key": "@",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "@"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "@"
       },
       {
         "key": "A",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "A"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "A"
       },
       {
         "key": "B",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "B"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "B"
       },
       {
         "key": "C",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "C"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "C"
       },
       {
         "key": "D",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "D"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "D"
       },
       {
         "key": "E",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "E"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "E"
       },
       {
         "key": "F",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "F"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "F"
       },
       {
         "key": "G",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "G"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "G"
       },
       {
         "key": "H",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "H"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "H"
       },
       {
         "key": "I",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "I"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "I"
       },
       {
         "key": "J",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "J"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "J"
       },
       {
         "key": "K",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "K"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "K"
       },
       {
         "key": "L",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "L"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "L"
       },
       {
         "key": "M",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "M"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "M"
       },
       {
         "key": "N",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "N"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "N"
       },
       {
         "key": "O",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "O"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "O"
       },
       {
         "key": "P",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "P"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "P"
       },
       {
         "key": "Q",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "Q"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "Q"
       },
       {
         "key": "R",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "R"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "R"
       },
       {
         "key": "S",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "S"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "S"
       },
       {
         "key": "T",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "T"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "T"
       },
       {
         "key": "U",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "U"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "U"
       },
       {
         "key": "V",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "V"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "V"
       },
       {
         "key": "W",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "W"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "W"
       },
       {
         "key": "X",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "X"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "X"
       },
       {
         "key": "Y",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "Y"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "Y"
       },
       {
         "key": "Z",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "Z"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "Z"
       },
       {
         "key": "[",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "["
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "["
       },
       {
         "key": "\\",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "\\"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "\\"
       },
       {
         "key": "]",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "]"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "]"
       },
       {
         "key": "^",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "^"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "^"
       },
       {
         "key": "_",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "_"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "_"
       },
       {
         "key": "`",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "`"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "`"
       },
       {
         "key": "a",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "a"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "a"
       },
       {
         "key": "b",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "b"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "b"
       },
       {
         "key": "c",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "c"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "c"
       },
       {
         "key": "d",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "d"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "d"
       },
       {
         "key": "e",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "e"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "e"
       },
       {
         "key": "f",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "f"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "f"
       },
       {
         "key": "g",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "g"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "g"
       },
       {
         "key": "h",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "h"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "h"
       },
       {
         "key": "i",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "i"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "i"
       },
       {
         "key": "j",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "j"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "j"
       },
       {
         "key": "k",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "k"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "k"
       },
       {
         "key": "l",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "l"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "l"
       },
       {
         "key": "m",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "m"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "m"
       },
       {
         "key": "n",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "n"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "n"
       },
       {
         "key": "o",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "o"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "o"
       },
       {
         "key": "p",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "p"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "p"
       },
       {
         "key": "q",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "q"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "q"
       },
       {
         "key": "r",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "r"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "r"
       },
       {
         "key": "s",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "s"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "s"
       },
       {
         "key": "t",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "t"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "t"
       },
       {
         "key": "u",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "u"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "u"
       },
       {
         "key": "v",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "v"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "v"
       },
       {
         "key": "w",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "w"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "w"
       },
       {
         "key": "x",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "x"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "x"
       },
       {
         "key": "y",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "y"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "y"
       },
       {
         "key": "z",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "z"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "z"
       },
       {
         "key": "{",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "{"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "{"
       },
       {
         "key": "|",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "|"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "|"
       },
       {
         "key": "}",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "}"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "}"
       },
       {
         "key": "~",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.RegisterInsertCommand",
-        "args": [
-          "~"
-        ]
+        "command": "emacs-mcx.insertRegister",
+        "args": "~"
       },
       {
         "key": "y",

--- a/package.json
+++ b/package.json
@@ -3999,581 +3999,581 @@
       },
       {
         "key": "s",
-        "command": "emacs-mcx.StartRegisterSaveCommand",
+        "command": "emacs-mcx.startRegisterCopyCommand",
         "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": "i",
-        "command": "emacs-mcx.StartRegisterInsertCommand",
+        "command": "emacs-mcx.startRegisterInsertCommand",
         "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": " ",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": " "
       },
       {
         "key": "!",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "!"
       },
       {
         "key": "\"",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "\""
       },
       {
         "key": "#",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "#"
       },
       {
         "key": "$",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "$"
       },
       {
         "key": "%",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "%"
       },
       {
         "key": "&",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "&"
       },
       {
         "key": "'",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "'"
       },
       {
         "key": "(",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "("
       },
       {
         "key": ")",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": ")"
       },
       {
         "key": "*",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "*"
       },
       {
         "key": "+",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "+"
       },
       {
         "key": ",",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": ","
       },
       {
         "key": "-",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "-"
       },
       {
         "key": ".",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "."
       },
       {
         "key": "/",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "/"
       },
       {
         "key": "0",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "0"
       },
       {
         "key": "1",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "1"
       },
       {
         "key": "2",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "2"
       },
       {
         "key": "3",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "3"
       },
       {
         "key": "4",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "4"
       },
       {
         "key": "5",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "5"
       },
       {
         "key": "6",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "6"
       },
       {
         "key": "7",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "7"
       },
       {
         "key": "8",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "8"
       },
       {
         "key": "9",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "9"
       },
       {
         "key": ":",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": ":"
       },
       {
         "key": ";",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": ";"
       },
       {
         "key": "<",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "<"
       },
       {
         "key": "=",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "="
       },
       {
         "key": ">",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": ">"
       },
       {
         "key": "?",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "?"
       },
       {
         "key": "@",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "@"
       },
       {
         "key": "A",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "A"
       },
       {
         "key": "B",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "B"
       },
       {
         "key": "C",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "C"
       },
       {
         "key": "D",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "D"
       },
       {
         "key": "E",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "E"
       },
       {
         "key": "F",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "F"
       },
       {
         "key": "G",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "G"
       },
       {
         "key": "H",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "H"
       },
       {
         "key": "I",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "I"
       },
       {
         "key": "J",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "J"
       },
       {
         "key": "K",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "K"
       },
       {
         "key": "L",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "L"
       },
       {
         "key": "M",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "M"
       },
       {
         "key": "N",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "N"
       },
       {
         "key": "O",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "O"
       },
       {
         "key": "P",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "P"
       },
       {
         "key": "Q",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "Q"
       },
       {
         "key": "R",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "R"
       },
       {
         "key": "S",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "S"
       },
       {
         "key": "T",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "T"
       },
       {
         "key": "U",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "U"
       },
       {
         "key": "V",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "V"
       },
       {
         "key": "W",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "W"
       },
       {
         "key": "X",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "X"
       },
       {
         "key": "Y",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "Y"
       },
       {
         "key": "Z",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "Z"
       },
       {
         "key": "[",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "["
       },
       {
         "key": "\\",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "\\"
       },
       {
         "key": "]",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "]"
       },
       {
         "key": "^",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "^"
       },
       {
         "key": "_",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "_"
       },
       {
         "key": "`",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "`"
       },
       {
         "key": "a",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "a"
       },
       {
         "key": "b",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "b"
       },
       {
         "key": "c",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "c"
       },
       {
         "key": "d",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "d"
       },
       {
         "key": "e",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "e"
       },
       {
         "key": "f",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "f"
       },
       {
         "key": "g",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "g"
       },
       {
         "key": "h",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "h"
       },
       {
         "key": "i",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "i"
       },
       {
         "key": "j",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "j"
       },
       {
         "key": "k",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "k"
       },
       {
         "key": "l",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "l"
       },
       {
         "key": "m",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "m"
       },
       {
         "key": "n",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "n"
       },
       {
         "key": "o",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "o"
       },
       {
         "key": "p",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "p"
       },
       {
         "key": "q",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "q"
       },
       {
         "key": "r",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "r"
       },
       {
         "key": "s",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "s"
       },
       {
         "key": "t",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "t"
       },
       {
         "key": "u",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "u"
       },
       {
         "key": "v",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "v"
       },
       {
         "key": "w",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "w"
       },
       {
         "key": "x",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "x"
       },
       {
         "key": "y",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "y"
       },
       {
         "key": "z",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "z"
       },
       {
         "key": "{",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "{"
       },
       {
         "key": "|",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "|"
       },
       {
         "key": "}",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "}"
       },
       {
         "key": "~",
-        "when": "emacs-mcx.inRegisterSaveMode && editorTextFocus",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
         "command": "emacs-mcx.copyToRegister",
         "args": "~"
       },

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -4,36 +4,36 @@ import { EmacsCommand, ITextEditorInterruptionHandler } from ".";
 import { getNonEmptySelections, makeSelectionsEmpty } from "./helpers/selection";
 
 // Will bind this this to C-x r s
-export class StartRegisterSaveCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
-  public readonly id = "StartRegisterSaveCommand";
+export class StartRegisterCopyCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
+  public readonly id = "startRegisterCopyCommand";
 
-  private acceptingRegisterSaveCommand = false;
+  private acceptingRegisterCopyCommand = false;
 
-  private startRegisterSaveCommand(): void {
-    this.acceptingRegisterSaveCommand = true;
+  private startRegisterCopyCommand(): void {
+    this.acceptingRegisterCopyCommand = true;
     vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRectCommand", false);
-    vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterSaveMode", true);
+    vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterCopyMode", true);
   }
 
-  private stopRegisterSaveCommand(): void {
-    this.acceptingRegisterSaveCommand = false;
-    vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterSaveMode", false);
+  private stopRegisterCopyCommand(): void {
+    this.acceptingRegisterCopyCommand = false;
+    vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterCopyMode", false);
   }
 
   public run(): void {
-    this.startRegisterSaveCommand();
+    this.startRegisterCopyCommand();
   }
 
   public onDidInterruptTextEditor(): void {
-    if (this.acceptingRegisterSaveCommand) {
-      this.stopRegisterSaveCommand();
+    if (this.acceptingRegisterCopyCommand) {
+      this.stopRegisterCopyCommand();
     }
   }
 }
 
 // Will bind this this to C-x r i
 export class StartRegisterInsertCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
-  public readonly id = "StartRegisterInsertCommand";
+  public readonly id = "startRegisterInsertCommand";
 
   private acceptingRegisterInsertCommand = false;
 

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
+import { IEmacsController } from "../emulator";
 import { EmacsCommand, ITextEditorInterruptionHandler } from ".";
+import { getNonEmptySelections, makeSelectionsEmpty } from "./helpers/selection";
 
 // Will bind this this to C-x r s
 export class StartRegisterSaveCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
@@ -54,5 +56,102 @@ export class StartRegisterInsertCommand extends EmacsCommand implements ITextEdi
     if (this.acceptingRegisterInsertCommand) {
       this.stopRegisterInsertCommand();
     }
+  }
+}
+
+export class CopyToRegister extends EmacsCommand {
+  public readonly id = "copyToRegister";
+
+  constructor(
+    emacsController: IEmacsController,
+    private readonly textRegister: Map<string, string>,
+  ) {
+    super(emacsController);
+  }
+
+  public run(
+    textEditor: vscode.TextEditor,
+    isInMarkMode: boolean,
+    prefixArgument: number | undefined,
+    args?: unknown[],
+  ): void | Thenable<void> {
+    const arg = args?.[0];
+    if (typeof arg !== "string") {
+      return;
+    }
+
+    const selectionsAfterRectDisabled =
+      this.emacsController.inRectMarkMode &&
+      this.emacsController.nativeSelections.map((selection) => {
+        const newLine = selection.active.line;
+        const newChar = Math.min(selection.active.character, selection.anchor.character);
+        return new vscode.Selection(newLine, newChar, newLine, newChar);
+      });
+    const selections = getNonEmptySelections(textEditor);
+    if (selectionsAfterRectDisabled) {
+      textEditor.selections = selectionsAfterRectDisabled;
+    }
+    // selections is now a list of non empty selections, iterate through them and
+    // build a single variable combinedtext
+    let i = 0;
+    let combinedtext = "";
+    while (i < selections.length) {
+      combinedtext = combinedtext + textEditor.document.getText(selections[i]);
+      i++;
+    }
+
+    const register_string = arg;
+    if (register_string == null) {
+      return;
+    }
+
+    this.textRegister.set(register_string, combinedtext);
+    // After copying the selection, get out of mark mode and de-select the selections
+    this.emacsController.exitMarkMode();
+    makeSelectionsEmpty(textEditor);
+  }
+}
+
+export class InsertRegister extends EmacsCommand {
+  public readonly id = "insertRegister";
+
+  constructor(
+    emacsController: IEmacsController,
+    private readonly textRegister: Map<string, string>,
+  ) {
+    super(emacsController);
+  }
+
+  public async run(
+    textEditor: vscode.TextEditor,
+    isInMarkMode: boolean,
+    prefixArgument: number | undefined,
+    args?: unknown[],
+  ): Promise<void> {
+    const arg = args?.[0];
+    if (typeof arg !== "string") {
+      return;
+    }
+
+    if (!this.textRegister.has(arg)) {
+      return;
+    }
+
+    const textToInsert = this.textRegister.get(arg);
+    if (textToInsert == undefined) {
+      return;
+    }
+    // Looking for how to insert-replace with selections highlighted.... must copy-paste from Yank command
+    const selections = textEditor.selections;
+
+    await textEditor.edit((editBuilder) => {
+      selections.forEach((selection) => {
+        if (!selection.isEmpty) {
+          editBuilder.delete(selection);
+        }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        editBuilder.insert(selection.start, textToInsert);
+      });
+    });
   }
 }

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -149,6 +149,8 @@ export class InsertRegister extends EmacsCommand {
     // Looking for how to insert-replace with selections highlighted.... must copy-paste from Yank command
     const selections = textEditor.selections;
 
+    this.emacsController.pushMark(selections.map((s) => s.active));
+
     await textEditor.edit((editBuilder) => {
       selections.forEach((selection) => {
         if (!selection.isEmpty) {

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { IEmacsController } from "../emulator";
+import { MessageManager } from "../message";
 import { EmacsCommand, ITextEditorInterruptionHandler } from ".";
 import { getNonEmptySelections, makeSelectionsEmpty } from "./helpers/selection";
 
@@ -13,6 +14,8 @@ export class StartRegisterCopyCommand extends EmacsCommand implements ITextEdito
     this.acceptingRegisterCopyCommand = true;
     vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRectCommand", false);
     vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterCopyMode", true);
+
+    MessageManager.showMessage("Copy to register: ");
   }
 
   private stopRegisterCopyCommand(): void {
@@ -41,6 +44,8 @@ export class StartRegisterInsertCommand extends EmacsCommand implements ITextEdi
     this.acceptingRegisterInsertCommand = true;
     vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRectCommand", false);
     vscode.commands.executeCommand("setContext", "emacs-mcx.inRegisterInsertMode", true);
+
+    MessageManager.showMessage("Insert from register: ");
   }
 
   private stopRegisterInsertCommand(): void {

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -192,7 +192,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.killYanker = killYanker;
     this.registerDisposable(killYanker);
 
-    this.commandRegistry.register(new TextRegisterCommands.StartRegisterSaveCommand(this));
+    this.commandRegistry.register(new TextRegisterCommands.StartRegisterCopyCommand(this));
     this.commandRegistry.register(new TextRegisterCommands.StartRegisterInsertCommand(this));
     this.commandRegistry.register(new TextRegisterCommands.CopyToRegister(this, textRegister));
     this.commandRegistry.register(new TextRegisterCommands.InsertRegister(this, textRegister));

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -11,8 +11,7 @@ import * as KillCommands from "./commands/kill";
 import * as MoveCommands from "./commands/move";
 import * as PareditCommands from "./commands/paredit";
 import * as RectangleCommands from "./commands/rectangle";
-import { StartRegisterSaveCommand, StartRegisterInsertCommand } from "./commands/registers";
-import { getNonEmptySelections } from "./commands/helpers/selection";
+import * as TextRegisterCommands from "./commands/registers";
 import { RecenterTopBottom } from "./commands/recenter";
 import { EmacsCommandRegistry } from "./commands/registry";
 import { KillYanker } from "./kill-yank";
@@ -41,7 +40,6 @@ export interface IEmacsController {
 
 export class EmacsEmulator implements IEmacsController, vscode.Disposable {
   private textEditor: TextEditor;
-  private textRegister: Map<string, string>;
 
   private commandRegistry: EmacsCommandRegistry;
 
@@ -128,7 +126,6 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.textEditor = textEditor;
     this.setNativeSelections(this.rectMode ? [] : textEditor.selections); // TODO: `[]` is workaround.
 
-    this.textRegister = textRegister;
     this.markRing = new MarkRing(Configuration.instance.markRingMax);
     this.prevExchangedMarks = null;
 
@@ -195,8 +192,10 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.killYanker = killYanker;
     this.registerDisposable(killYanker);
 
-    this.commandRegistry.register(new StartRegisterSaveCommand(this));
-    this.commandRegistry.register(new StartRegisterInsertCommand(this));
+    this.commandRegistry.register(new TextRegisterCommands.StartRegisterSaveCommand(this));
+    this.commandRegistry.register(new TextRegisterCommands.StartRegisterInsertCommand(this));
+    this.commandRegistry.register(new TextRegisterCommands.CopyToRegister(this, textRegister));
+    this.commandRegistry.register(new TextRegisterCommands.InsertRegister(this, textRegister));
 
     const rectangleState: RectangleCommands.RectangleState = {
       latestKilledRectangle: [],
@@ -219,6 +218,8 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.commandRegistry.register(new PareditCommands.KillSexp(this, killYanker));
     this.commandRegistry.register(new PareditCommands.BackwardKillSexp(this, killYanker));
     this.commandRegistry.register(new PareditCommands.PareditKill(this, killYanker));
+
+    this.commandRegistry.register;
 
     this.commandRegistry.register(new AddSelectionToNextFindMatch(this));
     this.commandRegistry.register(new AddSelectionToPreviousFindMatch(this));
@@ -615,60 +616,5 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
 
   private onDidInterruptTextEditor() {
     this.commandRegistry.onInterrupt();
-  }
-
-  public saveRegister(arg: string): void {
-    const selectionsAfterRectDisabled =
-      this.inRectMarkMode &&
-      this.nativeSelections.map((selection) => {
-        const newLine = selection.active.line;
-        const newChar = Math.min(selection.active.character, selection.anchor.character);
-        return new vscode.Selection(newLine, newChar, newLine, newChar);
-      });
-    const selections = getNonEmptySelections(this.textEditor);
-    if (selectionsAfterRectDisabled) {
-      this.textEditor.selections = selectionsAfterRectDisabled;
-    }
-    // selections is now a list of non empty selections, iterate through them and
-    // build a single variable combinedtext
-    let i = 0;
-    let combinedtext = "";
-    while (i < selections.length) {
-      combinedtext = combinedtext + this.textEditor.document.getText(selections[i]);
-      i++;
-    }
-
-    const register_string = arg;
-    if (register_string == null) {
-      return;
-    }
-
-    this.textRegister.set(register_string, combinedtext);
-    // After copying the selection, get out of mark mode and de-select the selections
-    this.exitMarkMode();
-    this.makeSelectionsEmpty();
-  }
-
-  public async insertRegister(arg: string): Promise<void> {
-    if (!this.textRegister.has(arg)) {
-      return;
-    }
-
-    const textToInsert = this.textRegister.get(arg);
-    if (textToInsert == undefined) {
-      return;
-    }
-    // Looking for how to insert-replace with selections highlighted.... must copy-paste from Yank command
-    const selections = this.textEditor.selections;
-
-    await this.textEditor.edit((editBuilder) => {
-      selections.forEach((selection) => {
-        if (!selection.isEmpty) {
-          editBuilder.delete(selection);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        editBuilder.insert(selection.start, textToInsert);
-      });
-    });
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -362,12 +362,12 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("paredit.backwardKillSexp");
   });
 
-  registerEmulatorCommand("emacs-mcx.StartRegisterSaveCommand", (emulator) => {
-    return emulator.runCommand("StartRegisterSaveCommand");
+  registerEmulatorCommand("emacs-mcx.startRegisterCopyCommand", (emulator) => {
+    return emulator.runCommand("startRegisterCopyCommand");
   });
 
-  registerEmulatorCommand("emacs-mcx.StartRegisterInsertCommand", (emulator) => {
-    return emulator.runCommand("StartRegisterInsertCommand");
+  registerEmulatorCommand("emacs-mcx.startRegisterInsertCommand", (emulator) => {
+    return emulator.runCommand("startRegisterInsertCommand");
   });
 
   registerEmulatorCommand("emacs-mcx.copyToRegister", (emulator, ...args) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -370,26 +370,12 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("StartRegisterInsertCommand");
   });
 
-  registerEmulatorCommand("emacs-mcx.RegisterSaveCommand", (emulator, arg0) => {
-    if (!Array.isArray(arg0)) {
-      return;
-    }
-    const arg = arg0[0];
-    if (typeof arg !== "string") {
-      return;
-    }
-    return emulator.saveRegister(arg);
+  registerEmulatorCommand("emacs-mcx.copyToRegister", (emulator, ...args) => {
+    return emulator.runCommand("copyToRegister", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.RegisterInsertCommand", (emulator, arg0) => {
-    if (!Array.isArray(arg0)) {
-      return;
-    }
-    const arg = arg0[0];
-    if (typeof arg !== "string") {
-      return;
-    }
-    return emulator.insertRegister(arg);
+  registerEmulatorCommand("emacs-mcx.insertRegister", (emulator, ...args) => {
+    return emulator.runCommand("insertRegister", args);
   });
 
   registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, arg0) => {

--- a/src/test/suite/text-register.test.ts
+++ b/src/test/suite/text-register.test.ts
@@ -18,23 +18,23 @@ suite("Text registers", () => {
 
   test("copy and paste", async () => {
     activeTextEditor.selections = [new vscode.Selection(0, 0, 1, 2)];
-    emulator.saveRegister("a");
+    await emulator.runCommand("copyToRegister", ["a"]);
 
     // Empty string
     activeTextEditor.selections = [new vscode.Selection(0, 0, 0, 0)];
-    emulator.saveRegister("b");
+    await emulator.runCommand("copyToRegister", ["b"]);
 
     await clearTextEditor(activeTextEditor);
 
-    await emulator.insertRegister("c");
+    await emulator.runCommand("insertRegister", ["c"]);
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
-    await emulator.insertRegister("b");
+    await emulator.runCommand("insertRegister", ["b"]);
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
-    await emulator.insertRegister("a");
+    await emulator.runCommand("insertRegister", ["a"]);
     assertTextEqual(activeTextEditor, "0123456789\nab");
     assertCursorsEqual(activeTextEditor, [1, 2]);
   });


### PR DESCRIPTION
- Move the text register commands to command classes
- Rename text register commands and contexts following the original Emacs command names
- Add messages
