### PR TITLE
dev/revert id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,11 @@ All notable changes to the "emacs-mcx" extension will be documented in this file
 
 ## [Unreleased]
 
-## [0.59.1] - 2024-02-12
+## [0.59.1]
 
-### Changed
+Skipped.
 
-- Change the `publisher` field in `package.json` from `tuttieee` to `whitphx`, #1853.
-- Change the `name` field in `package.json` from `emacs-mcx` to `awesome-emacs`, #1854.
-
-## [0.59.0] - 2024-02-12
+## [0.59.0]
 
 Skipped.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "awesome-emacs",
+  "name": "emacs-mcx",
   "displayName": "Awesome Emacs Keymap",
   "description": "Emacs Friendly Keymap with multi cursor support, improved mark-mode experience, clipboard and kill-ring integration, and lots of improvements and bug fixes.",
   "version": "0.59.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Awesome Emacs Keymap",
   "description": "Emacs Friendly Keymap with multi cursor support, improved mark-mode experience, clipboard and kill-ring integration, and lots of improvements and bug fixes.",
   "version": "0.59.1",
-  "publisher": "whitphx",
+  "publisher": "tuttieee",
   "repository": {
     "type": "git",
     "url": "https://github.com/whitphx/vscode-emacs-mcx"


### PR DESCRIPTION
- Revert "Change the `name` field in `package.json` to "awesome-emacs" because of an error saying "Error: The extension 'emacs-mcx' already exists in the Marketplace. Please use a different 'name' in the package.json file" (#1854)"
- Revert "Change the \`publisher\` field in \`package.json`\ to "whitphx" (#1853)"
- Update CHANGELOG.md
