### PR TITLE
Fix register commands

### DIFF
--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -282,14 +282,14 @@ export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
   for (const char of ASSIGNABLE_KEYS) {
     keybindings.push({
       key: char,
-      when: "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+      when: "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
       command: "emacs-mcx.registerCommand",
       args: char,
     });
   }
   keybindings.push({
     key: "space",
-    when: "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+    when: "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
     command: "emacs-mcx.registerCommand",
     args: " ",
   });

--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -283,14 +283,14 @@ export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
     keybindings.push({
       key: char,
       when: "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-      command: "emacs-mcx.registerCommand",
+      command: "emacs-mcx.someRegisterCommand",
       args: char,
     });
   }
   keybindings.push({
     key: "space",
     when: "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-    command: "emacs-mcx.registerCommand",
+    command: "emacs-mcx.someRegisterCommand",
     args: " ",
   });
   return keybindings;

--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -279,35 +279,22 @@ export function generateKeybindingsForTypeCharInRectMarkMode(): KeyBinding[] {
 export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
   const keybindings: KeyBinding[] = [];
 
-  for (const char of ASSIGNABLE_KEYS) {
+  const keyAndChars = ASSIGNABLE_KEYS.map((key) => ({ key, char: key })).concat([{ key: "space", char: " " }]);
+
+  for (const { key, char } of keyAndChars) {
     keybindings.push({
-      key: char,
+      key,
       when: "emacs-mcx.inRegisterCopyMode && editorTextFocus",
       command: "emacs-mcx.copyToRegister",
       args: char,
     });
-  }
-  keybindings.push({
-    key: "space",
-    when: "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-    command: "emacs-mcx.copyToRegister",
-    args: " ",
-  });
-
-  for (const char of ASSIGNABLE_KEYS) {
     keybindings.push({
-      key: char,
+      key,
       when: "emacs-mcx.inRegisterInsertMode && editorTextFocus",
       command: "emacs-mcx.insertRegister",
       args: char,
     });
   }
-  keybindings.push({
-    key: "space",
-    when: "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-    command: "emacs-mcx.insertRegister",
-    args: " ",
-  });
   return keybindings;
 }
 

--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -279,22 +279,20 @@ export function generateKeybindingsForTypeCharInRectMarkMode(): KeyBinding[] {
 export function generateKeybindingsForRegisterCommands(): KeyBinding[] {
   const keybindings: KeyBinding[] = [];
 
-  const keyAndChars = ASSIGNABLE_KEYS.map((key) => ({ key, char: key })).concat([{ key: "space", char: " " }]);
-
-  for (const { key, char } of keyAndChars) {
+  for (const char of ASSIGNABLE_KEYS) {
     keybindings.push({
-      key,
-      when: "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-      command: "emacs-mcx.copyToRegister",
-      args: char,
-    });
-    keybindings.push({
-      key,
-      when: "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-      command: "emacs-mcx.insertRegister",
+      key: char,
+      when: "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+      command: "emacs-mcx.registerCommand",
       args: char,
     });
   }
+  keybindings.push({
+    key: "space",
+    when: "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+    command: "emacs-mcx.registerCommand",
+    args: " ",
+  });
   return keybindings;
 }
 

--- a/keybindings.json
+++ b/keybindings.json
@@ -763,12 +763,12 @@
     },
     {
       "key": "s", // ctrl+x r s
-      "command": "emacs-mcx.startRegisterCopyCommand",
+      "command": "emacs-mcx.preCopyToRegister",
       "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {
       "key": "i", // ctrl+x r i
-      "command": "emacs-mcx.startRegisterInsertCommand",
+      "command": "emacs-mcx.preInsertRegister",
       "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
     },
     {

--- a/package.json
+++ b/package.json
@@ -3855,890 +3855,446 @@
       },
       {
         "key": "'",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "'"
-      },
-      {
-        "key": "'",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "'"
       },
       {
         "key": ",",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": ","
-      },
-      {
-        "key": ",",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": ","
       },
       {
         "key": "-",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "-"
-      },
-      {
-        "key": "-",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "-"
       },
       {
         "key": ".",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "."
-      },
-      {
-        "key": ".",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "."
       },
       {
         "key": "/",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "/"
-      },
-      {
-        "key": "/",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "/"
       },
       {
         "key": "0",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "0"
-      },
-      {
-        "key": "0",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "0"
       },
       {
         "key": "1",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "1"
-      },
-      {
-        "key": "1",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "1"
       },
       {
         "key": "2",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "2"
-      },
-      {
-        "key": "2",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "2"
       },
       {
         "key": "3",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "3"
-      },
-      {
-        "key": "3",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "3"
       },
       {
         "key": "4",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "4"
-      },
-      {
-        "key": "4",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "4"
       },
       {
         "key": "5",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "5"
-      },
-      {
-        "key": "5",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "5"
       },
       {
         "key": "6",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "6"
-      },
-      {
-        "key": "6",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "6"
       },
       {
         "key": "7",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "7"
-      },
-      {
-        "key": "7",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "7"
       },
       {
         "key": "8",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "8"
-      },
-      {
-        "key": "8",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "8"
       },
       {
         "key": "9",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "9"
-      },
-      {
-        "key": "9",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "9"
       },
       {
         "key": ";",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": ";"
-      },
-      {
-        "key": ";",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": ";"
       },
       {
         "key": "=",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "="
-      },
-      {
-        "key": "=",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "="
       },
       {
         "key": "A",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "A"
-      },
-      {
-        "key": "A",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "A"
       },
       {
         "key": "B",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "B"
-      },
-      {
-        "key": "B",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "B"
       },
       {
         "key": "C",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "C"
-      },
-      {
-        "key": "C",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "C"
       },
       {
         "key": "D",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "D"
-      },
-      {
-        "key": "D",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "D"
       },
       {
         "key": "E",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "E"
-      },
-      {
-        "key": "E",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "E"
       },
       {
         "key": "F",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "F"
-      },
-      {
-        "key": "F",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "F"
       },
       {
         "key": "G",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "G"
-      },
-      {
-        "key": "G",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "G"
       },
       {
         "key": "H",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "H"
-      },
-      {
-        "key": "H",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "H"
       },
       {
         "key": "I",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "I"
-      },
-      {
-        "key": "I",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "I"
       },
       {
         "key": "J",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "J"
-      },
-      {
-        "key": "J",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "J"
       },
       {
         "key": "K",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "K"
-      },
-      {
-        "key": "K",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "K"
       },
       {
         "key": "L",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "L"
-      },
-      {
-        "key": "L",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "L"
       },
       {
         "key": "M",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "M"
-      },
-      {
-        "key": "M",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "M"
       },
       {
         "key": "N",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "N"
-      },
-      {
-        "key": "N",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "N"
       },
       {
         "key": "O",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "O"
-      },
-      {
-        "key": "O",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "O"
       },
       {
         "key": "P",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "P"
-      },
-      {
-        "key": "P",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "P"
       },
       {
         "key": "Q",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "Q"
-      },
-      {
-        "key": "Q",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "Q"
       },
       {
         "key": "R",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "R"
-      },
-      {
-        "key": "R",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "R"
       },
       {
         "key": "S",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "S"
-      },
-      {
-        "key": "S",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "S"
       },
       {
         "key": "T",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "T"
-      },
-      {
-        "key": "T",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "T"
       },
       {
         "key": "U",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "U"
-      },
-      {
-        "key": "U",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "U"
       },
       {
         "key": "V",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "V"
-      },
-      {
-        "key": "V",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "V"
       },
       {
         "key": "W",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "W"
-      },
-      {
-        "key": "W",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "W"
       },
       {
         "key": "X",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "X"
-      },
-      {
-        "key": "X",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "X"
       },
       {
         "key": "Y",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "Y"
-      },
-      {
-        "key": "Y",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "Y"
       },
       {
         "key": "Z",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "Z"
-      },
-      {
-        "key": "Z",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "Z"
       },
       {
         "key": "[",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "["
-      },
-      {
-        "key": "[",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "["
       },
       {
         "key": "\\",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "\\"
-      },
-      {
-        "key": "\\",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "\\"
       },
       {
         "key": "]",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "]"
-      },
-      {
-        "key": "]",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "]"
       },
       {
         "key": "`",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "`"
-      },
-      {
-        "key": "`",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "`"
       },
       {
         "key": "a",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "a"
-      },
-      {
-        "key": "a",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "a"
       },
       {
         "key": "b",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "b"
-      },
-      {
-        "key": "b",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "b"
       },
       {
         "key": "c",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "c"
-      },
-      {
-        "key": "c",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "c"
       },
       {
         "key": "d",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "d"
-      },
-      {
-        "key": "d",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "d"
       },
       {
         "key": "e",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "e"
-      },
-      {
-        "key": "e",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "e"
       },
       {
         "key": "f",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "f"
-      },
-      {
-        "key": "f",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "f"
       },
       {
         "key": "g",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "g"
-      },
-      {
-        "key": "g",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "g"
       },
       {
         "key": "h",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "h"
-      },
-      {
-        "key": "h",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "h"
       },
       {
         "key": "i",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "i"
-      },
-      {
-        "key": "i",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "i"
       },
       {
         "key": "j",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "j"
-      },
-      {
-        "key": "j",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "j"
       },
       {
         "key": "k",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "k"
-      },
-      {
-        "key": "k",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "k"
       },
       {
         "key": "l",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "l"
-      },
-      {
-        "key": "l",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "l"
       },
       {
         "key": "m",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "m"
-      },
-      {
-        "key": "m",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "m"
       },
       {
         "key": "n",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "n"
-      },
-      {
-        "key": "n",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "n"
       },
       {
         "key": "o",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "o"
-      },
-      {
-        "key": "o",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "o"
       },
       {
         "key": "p",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "p"
-      },
-      {
-        "key": "p",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "p"
       },
       {
         "key": "q",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "q"
-      },
-      {
-        "key": "q",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "q"
       },
       {
         "key": "r",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "r"
-      },
-      {
-        "key": "r",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "r"
       },
       {
         "key": "s",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "s"
-      },
-      {
-        "key": "s",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "s"
       },
       {
         "key": "t",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "t"
-      },
-      {
-        "key": "t",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "t"
       },
       {
         "key": "u",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "u"
-      },
-      {
-        "key": "u",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "u"
       },
       {
         "key": "v",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "v"
-      },
-      {
-        "key": "v",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "v"
       },
       {
         "key": "w",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "w"
-      },
-      {
-        "key": "w",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "w"
       },
       {
         "key": "x",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "x"
-      },
-      {
-        "key": "x",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "x"
       },
       {
         "key": "y",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "y"
-      },
-      {
-        "key": "y",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "y"
       },
       {
         "key": "z",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "z"
-      },
-      {
-        "key": "z",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": "z"
       },
       {
         "key": "space",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": " "
-      },
-      {
-        "key": "space",
-        "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
-        "command": "emacs-mcx.insertRegister",
+        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "command": "emacs-mcx.registerCommand",
         "args": " "
       },
       {

--- a/package.json
+++ b/package.json
@@ -3845,12 +3845,12 @@
       },
       {
         "key": "s",
-        "command": "emacs-mcx.startRegisterCopyCommand",
+        "command": "emacs-mcx.preCopyToRegister",
         "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "key": "i",
-        "command": "emacs-mcx.startRegisterInsertCommand",
+        "command": "emacs-mcx.preInsertRegister",
         "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {

--- a/package.json
+++ b/package.json
@@ -3855,445 +3855,445 @@
       },
       {
         "key": "'",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "'"
       },
       {
         "key": ",",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": ","
       },
       {
         "key": "-",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "-"
       },
       {
         "key": ".",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "."
       },
       {
         "key": "/",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "/"
       },
       {
         "key": "0",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "0"
       },
       {
         "key": "1",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "1"
       },
       {
         "key": "2",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "2"
       },
       {
         "key": "3",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "3"
       },
       {
         "key": "4",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "4"
       },
       {
         "key": "5",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "5"
       },
       {
         "key": "6",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "6"
       },
       {
         "key": "7",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "7"
       },
       {
         "key": "8",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "8"
       },
       {
         "key": "9",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "9"
       },
       {
         "key": ";",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": ";"
       },
       {
         "key": "=",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "="
       },
       {
         "key": "A",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "A"
       },
       {
         "key": "B",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "B"
       },
       {
         "key": "C",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "C"
       },
       {
         "key": "D",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "D"
       },
       {
         "key": "E",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "E"
       },
       {
         "key": "F",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "F"
       },
       {
         "key": "G",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "G"
       },
       {
         "key": "H",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "H"
       },
       {
         "key": "I",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "I"
       },
       {
         "key": "J",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "J"
       },
       {
         "key": "K",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "K"
       },
       {
         "key": "L",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "L"
       },
       {
         "key": "M",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "M"
       },
       {
         "key": "N",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "N"
       },
       {
         "key": "O",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "O"
       },
       {
         "key": "P",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "P"
       },
       {
         "key": "Q",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "Q"
       },
       {
         "key": "R",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "R"
       },
       {
         "key": "S",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "S"
       },
       {
         "key": "T",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "T"
       },
       {
         "key": "U",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "U"
       },
       {
         "key": "V",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "V"
       },
       {
         "key": "W",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "W"
       },
       {
         "key": "X",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "X"
       },
       {
         "key": "Y",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "Y"
       },
       {
         "key": "Z",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "Z"
       },
       {
         "key": "[",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "["
       },
       {
         "key": "\\",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "\\"
       },
       {
         "key": "]",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "]"
       },
       {
         "key": "`",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "`"
       },
       {
         "key": "a",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "a"
       },
       {
         "key": "b",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "b"
       },
       {
         "key": "c",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "c"
       },
       {
         "key": "d",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "d"
       },
       {
         "key": "e",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "e"
       },
       {
         "key": "f",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "f"
       },
       {
         "key": "g",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "g"
       },
       {
         "key": "h",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "h"
       },
       {
         "key": "i",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "i"
       },
       {
         "key": "j",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "j"
       },
       {
         "key": "k",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "k"
       },
       {
         "key": "l",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "l"
       },
       {
         "key": "m",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "m"
       },
       {
         "key": "n",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "n"
       },
       {
         "key": "o",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "o"
       },
       {
         "key": "p",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "p"
       },
       {
         "key": "q",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "q"
       },
       {
         "key": "r",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "r"
       },
       {
         "key": "s",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "s"
       },
       {
         "key": "t",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "t"
       },
       {
         "key": "u",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "u"
       },
       {
         "key": "v",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "v"
       },
       {
         "key": "w",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "w"
       },
       {
         "key": "x",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "x"
       },
       {
         "key": "y",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "y"
       },
       {
         "key": "z",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": "z"
       },
       {
         "key": "space",
-        "when": "emacs-mcx.acceptingRegisterKey && editorTextFocus",
+        "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
         "command": "emacs-mcx.registerCommand",
         "args": " "
       },

--- a/package.json
+++ b/package.json
@@ -3856,445 +3856,445 @@
       {
         "key": "'",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "'"
       },
       {
         "key": ",",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": ","
       },
       {
         "key": "-",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "-"
       },
       {
         "key": ".",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "."
       },
       {
         "key": "/",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "/"
       },
       {
         "key": "0",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "0"
       },
       {
         "key": "1",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "1"
       },
       {
         "key": "2",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "2"
       },
       {
         "key": "3",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "3"
       },
       {
         "key": "4",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "4"
       },
       {
         "key": "5",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "5"
       },
       {
         "key": "6",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "6"
       },
       {
         "key": "7",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "7"
       },
       {
         "key": "8",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "8"
       },
       {
         "key": "9",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "9"
       },
       {
         "key": ";",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": ";"
       },
       {
         "key": "=",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "="
       },
       {
         "key": "A",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "A"
       },
       {
         "key": "B",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "B"
       },
       {
         "key": "C",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "C"
       },
       {
         "key": "D",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "D"
       },
       {
         "key": "E",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "E"
       },
       {
         "key": "F",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "F"
       },
       {
         "key": "G",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "G"
       },
       {
         "key": "H",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "H"
       },
       {
         "key": "I",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "I"
       },
       {
         "key": "J",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "J"
       },
       {
         "key": "K",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "K"
       },
       {
         "key": "L",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "L"
       },
       {
         "key": "M",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "M"
       },
       {
         "key": "N",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "N"
       },
       {
         "key": "O",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "O"
       },
       {
         "key": "P",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "P"
       },
       {
         "key": "Q",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "Q"
       },
       {
         "key": "R",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "R"
       },
       {
         "key": "S",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "S"
       },
       {
         "key": "T",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "T"
       },
       {
         "key": "U",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "U"
       },
       {
         "key": "V",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "V"
       },
       {
         "key": "W",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "W"
       },
       {
         "key": "X",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "X"
       },
       {
         "key": "Y",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "Y"
       },
       {
         "key": "Z",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "Z"
       },
       {
         "key": "[",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "["
       },
       {
         "key": "\\",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "\\"
       },
       {
         "key": "]",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "]"
       },
       {
         "key": "`",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "`"
       },
       {
         "key": "a",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "a"
       },
       {
         "key": "b",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "b"
       },
       {
         "key": "c",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "c"
       },
       {
         "key": "d",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "d"
       },
       {
         "key": "e",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "e"
       },
       {
         "key": "f",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "f"
       },
       {
         "key": "g",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "g"
       },
       {
         "key": "h",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "h"
       },
       {
         "key": "i",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "i"
       },
       {
         "key": "j",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "j"
       },
       {
         "key": "k",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "k"
       },
       {
         "key": "l",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "l"
       },
       {
         "key": "m",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "m"
       },
       {
         "key": "n",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "n"
       },
       {
         "key": "o",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "o"
       },
       {
         "key": "p",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "p"
       },
       {
         "key": "q",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "q"
       },
       {
         "key": "r",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "r"
       },
       {
         "key": "s",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "s"
       },
       {
         "key": "t",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "t"
       },
       {
         "key": "u",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "u"
       },
       {
         "key": "v",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "v"
       },
       {
         "key": "w",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "w"
       },
       {
         "key": "x",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "x"
       },
       {
         "key": "y",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "y"
       },
       {
         "key": "z",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": "z"
       },
       {
         "key": "space",
         "when": "emacs-mcx.acceptingRegisterCommand && editorTextFocus",
-        "command": "emacs-mcx.registerCommand",
+        "command": "emacs-mcx.someRegisterCommand",
         "args": " "
       },
       {

--- a/package.json
+++ b/package.json
@@ -3860,444 +3860,6 @@
         "args": "'"
       },
       {
-        "key": ",",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": ","
-      },
-      {
-        "key": "-",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "-"
-      },
-      {
-        "key": ".",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "."
-      },
-      {
-        "key": "/",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "/"
-      },
-      {
-        "key": "0",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "0"
-      },
-      {
-        "key": "1",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "1"
-      },
-      {
-        "key": "2",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "2"
-      },
-      {
-        "key": "3",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "3"
-      },
-      {
-        "key": "4",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "4"
-      },
-      {
-        "key": "5",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "5"
-      },
-      {
-        "key": "6",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "6"
-      },
-      {
-        "key": "7",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "7"
-      },
-      {
-        "key": "8",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "8"
-      },
-      {
-        "key": "9",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "9"
-      },
-      {
-        "key": ";",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": ";"
-      },
-      {
-        "key": "=",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "="
-      },
-      {
-        "key": "A",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "A"
-      },
-      {
-        "key": "B",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "B"
-      },
-      {
-        "key": "C",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "C"
-      },
-      {
-        "key": "D",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "D"
-      },
-      {
-        "key": "E",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "E"
-      },
-      {
-        "key": "F",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "F"
-      },
-      {
-        "key": "G",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "G"
-      },
-      {
-        "key": "H",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "H"
-      },
-      {
-        "key": "I",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "I"
-      },
-      {
-        "key": "J",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "J"
-      },
-      {
-        "key": "K",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "K"
-      },
-      {
-        "key": "L",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "L"
-      },
-      {
-        "key": "M",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "M"
-      },
-      {
-        "key": "N",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "N"
-      },
-      {
-        "key": "O",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "O"
-      },
-      {
-        "key": "P",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "P"
-      },
-      {
-        "key": "Q",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "Q"
-      },
-      {
-        "key": "R",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "R"
-      },
-      {
-        "key": "S",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "S"
-      },
-      {
-        "key": "T",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "T"
-      },
-      {
-        "key": "U",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "U"
-      },
-      {
-        "key": "V",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "V"
-      },
-      {
-        "key": "W",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "W"
-      },
-      {
-        "key": "X",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "X"
-      },
-      {
-        "key": "Y",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "Y"
-      },
-      {
-        "key": "Z",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "Z"
-      },
-      {
-        "key": "[",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "["
-      },
-      {
-        "key": "\\",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "\\"
-      },
-      {
-        "key": "]",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "]"
-      },
-      {
-        "key": "`",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "`"
-      },
-      {
-        "key": "a",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "a"
-      },
-      {
-        "key": "b",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "b"
-      },
-      {
-        "key": "c",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "c"
-      },
-      {
-        "key": "d",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "d"
-      },
-      {
-        "key": "e",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "e"
-      },
-      {
-        "key": "f",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "f"
-      },
-      {
-        "key": "g",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "g"
-      },
-      {
-        "key": "h",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "h"
-      },
-      {
-        "key": "i",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "i"
-      },
-      {
-        "key": "j",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "j"
-      },
-      {
-        "key": "k",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "k"
-      },
-      {
-        "key": "l",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "l"
-      },
-      {
-        "key": "m",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "m"
-      },
-      {
-        "key": "n",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "n"
-      },
-      {
-        "key": "o",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "o"
-      },
-      {
-        "key": "p",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "p"
-      },
-      {
-        "key": "q",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "q"
-      },
-      {
-        "key": "r",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "r"
-      },
-      {
-        "key": "s",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "s"
-      },
-      {
-        "key": "t",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "t"
-      },
-      {
-        "key": "u",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "u"
-      },
-      {
-        "key": "v",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "v"
-      },
-      {
-        "key": "w",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "w"
-      },
-      {
-        "key": "x",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "x"
-      },
-      {
-        "key": "y",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "y"
-      },
-      {
-        "key": "z",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": "z"
-      },
-      {
-        "key": "space",
-        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
-        "command": "emacs-mcx.copyToRegister",
-        "args": " "
-      },
-      {
         "key": "'",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
@@ -4305,9 +3867,21 @@
       },
       {
         "key": ",",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": ","
+      },
+      {
+        "key": ",",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": ","
+      },
+      {
+        "key": "-",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "-"
       },
       {
         "key": "-",
@@ -4317,9 +3891,21 @@
       },
       {
         "key": ".",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "."
+      },
+      {
+        "key": ".",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "."
+      },
+      {
+        "key": "/",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "/"
       },
       {
         "key": "/",
@@ -4329,9 +3915,21 @@
       },
       {
         "key": "0",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "0"
+      },
+      {
+        "key": "0",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "0"
+      },
+      {
+        "key": "1",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "1"
       },
       {
         "key": "1",
@@ -4341,9 +3939,21 @@
       },
       {
         "key": "2",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "2"
+      },
+      {
+        "key": "2",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "2"
+      },
+      {
+        "key": "3",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "3"
       },
       {
         "key": "3",
@@ -4353,9 +3963,21 @@
       },
       {
         "key": "4",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "4"
+      },
+      {
+        "key": "4",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "4"
+      },
+      {
+        "key": "5",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "5"
       },
       {
         "key": "5",
@@ -4365,9 +3987,21 @@
       },
       {
         "key": "6",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "6"
+      },
+      {
+        "key": "6",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "6"
+      },
+      {
+        "key": "7",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "7"
       },
       {
         "key": "7",
@@ -4377,9 +4011,21 @@
       },
       {
         "key": "8",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "8"
+      },
+      {
+        "key": "8",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "8"
+      },
+      {
+        "key": "9",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "9"
       },
       {
         "key": "9",
@@ -4389,9 +4035,21 @@
       },
       {
         "key": ";",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": ";"
+      },
+      {
+        "key": ";",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": ";"
+      },
+      {
+        "key": "=",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "="
       },
       {
         "key": "=",
@@ -4401,9 +4059,21 @@
       },
       {
         "key": "A",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "A"
+      },
+      {
+        "key": "A",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "A"
+      },
+      {
+        "key": "B",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "B"
       },
       {
         "key": "B",
@@ -4413,9 +4083,21 @@
       },
       {
         "key": "C",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "C"
+      },
+      {
+        "key": "C",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "C"
+      },
+      {
+        "key": "D",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "D"
       },
       {
         "key": "D",
@@ -4425,9 +4107,21 @@
       },
       {
         "key": "E",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "E"
+      },
+      {
+        "key": "E",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "E"
+      },
+      {
+        "key": "F",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "F"
       },
       {
         "key": "F",
@@ -4437,9 +4131,21 @@
       },
       {
         "key": "G",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "G"
+      },
+      {
+        "key": "G",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "G"
+      },
+      {
+        "key": "H",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "H"
       },
       {
         "key": "H",
@@ -4449,9 +4155,21 @@
       },
       {
         "key": "I",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "I"
+      },
+      {
+        "key": "I",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "I"
+      },
+      {
+        "key": "J",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "J"
       },
       {
         "key": "J",
@@ -4461,9 +4179,21 @@
       },
       {
         "key": "K",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "K"
+      },
+      {
+        "key": "K",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "K"
+      },
+      {
+        "key": "L",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "L"
       },
       {
         "key": "L",
@@ -4473,9 +4203,21 @@
       },
       {
         "key": "M",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "M"
+      },
+      {
+        "key": "M",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "M"
+      },
+      {
+        "key": "N",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "N"
       },
       {
         "key": "N",
@@ -4485,9 +4227,21 @@
       },
       {
         "key": "O",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "O"
+      },
+      {
+        "key": "O",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "O"
+      },
+      {
+        "key": "P",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "P"
       },
       {
         "key": "P",
@@ -4497,9 +4251,21 @@
       },
       {
         "key": "Q",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "Q"
+      },
+      {
+        "key": "Q",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "Q"
+      },
+      {
+        "key": "R",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "R"
       },
       {
         "key": "R",
@@ -4509,9 +4275,21 @@
       },
       {
         "key": "S",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "S"
+      },
+      {
+        "key": "S",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "S"
+      },
+      {
+        "key": "T",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "T"
       },
       {
         "key": "T",
@@ -4521,9 +4299,21 @@
       },
       {
         "key": "U",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "U"
+      },
+      {
+        "key": "U",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "U"
+      },
+      {
+        "key": "V",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "V"
       },
       {
         "key": "V",
@@ -4533,9 +4323,21 @@
       },
       {
         "key": "W",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "W"
+      },
+      {
+        "key": "W",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "W"
+      },
+      {
+        "key": "X",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "X"
       },
       {
         "key": "X",
@@ -4545,9 +4347,21 @@
       },
       {
         "key": "Y",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "Y"
+      },
+      {
+        "key": "Y",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "Y"
+      },
+      {
+        "key": "Z",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "Z"
       },
       {
         "key": "Z",
@@ -4557,9 +4371,21 @@
       },
       {
         "key": "[",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "["
+      },
+      {
+        "key": "[",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "["
+      },
+      {
+        "key": "\\",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "\\"
       },
       {
         "key": "\\",
@@ -4569,9 +4395,21 @@
       },
       {
         "key": "]",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "]"
+      },
+      {
+        "key": "]",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "]"
+      },
+      {
+        "key": "`",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "`"
       },
       {
         "key": "`",
@@ -4581,9 +4419,21 @@
       },
       {
         "key": "a",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "a"
+      },
+      {
+        "key": "a",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "a"
+      },
+      {
+        "key": "b",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "b"
       },
       {
         "key": "b",
@@ -4593,9 +4443,21 @@
       },
       {
         "key": "c",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "c"
+      },
+      {
+        "key": "c",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "c"
+      },
+      {
+        "key": "d",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "d"
       },
       {
         "key": "d",
@@ -4605,9 +4467,21 @@
       },
       {
         "key": "e",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "e"
+      },
+      {
+        "key": "e",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "e"
+      },
+      {
+        "key": "f",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "f"
       },
       {
         "key": "f",
@@ -4617,9 +4491,21 @@
       },
       {
         "key": "g",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "g"
+      },
+      {
+        "key": "g",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "g"
+      },
+      {
+        "key": "h",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "h"
       },
       {
         "key": "h",
@@ -4629,9 +4515,21 @@
       },
       {
         "key": "i",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "i"
+      },
+      {
+        "key": "i",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "i"
+      },
+      {
+        "key": "j",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "j"
       },
       {
         "key": "j",
@@ -4641,9 +4539,21 @@
       },
       {
         "key": "k",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "k"
+      },
+      {
+        "key": "k",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "k"
+      },
+      {
+        "key": "l",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "l"
       },
       {
         "key": "l",
@@ -4653,9 +4563,21 @@
       },
       {
         "key": "m",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "m"
+      },
+      {
+        "key": "m",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "m"
+      },
+      {
+        "key": "n",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "n"
       },
       {
         "key": "n",
@@ -4665,9 +4587,21 @@
       },
       {
         "key": "o",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "o"
+      },
+      {
+        "key": "o",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "o"
+      },
+      {
+        "key": "p",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "p"
       },
       {
         "key": "p",
@@ -4677,9 +4611,21 @@
       },
       {
         "key": "q",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "q"
+      },
+      {
+        "key": "q",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "q"
+      },
+      {
+        "key": "r",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "r"
       },
       {
         "key": "r",
@@ -4689,9 +4635,21 @@
       },
       {
         "key": "s",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "s"
+      },
+      {
+        "key": "s",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "s"
+      },
+      {
+        "key": "t",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "t"
       },
       {
         "key": "t",
@@ -4701,9 +4659,21 @@
       },
       {
         "key": "u",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "u"
+      },
+      {
+        "key": "u",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "u"
+      },
+      {
+        "key": "v",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "v"
       },
       {
         "key": "v",
@@ -4713,9 +4683,21 @@
       },
       {
         "key": "w",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "w"
+      },
+      {
+        "key": "w",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "w"
+      },
+      {
+        "key": "x",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "x"
       },
       {
         "key": "x",
@@ -4725,15 +4707,33 @@
       },
       {
         "key": "y",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "y"
+      },
+      {
+        "key": "y",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "y"
       },
       {
         "key": "z",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": "z"
+      },
+      {
+        "key": "z",
         "when": "emacs-mcx.inRegisterInsertMode && editorTextFocus",
         "command": "emacs-mcx.insertRegister",
         "args": "z"
+      },
+      {
+        "key": "space",
+        "when": "emacs-mcx.inRegisterCopyMode && editorTextFocus",
+        "command": "emacs-mcx.copyToRegister",
+        "args": " "
       },
       {
         "key": "space",

--- a/src/commands/rectangle.ts
+++ b/src/commands/rectangle.ts
@@ -102,10 +102,9 @@ abstract class EditRectangle extends RectangleKillYankCommand {
       await deleteRanges(textEditor, rectSelections);
 
       revealPrimaryActive(textEditor);
-
-      this.emacsController.exitMarkMode();
     }
 
+    this.emacsController.exitMarkMode();
     makeSelectionsEmpty(textEditor);
   }
 }

--- a/src/commands/rectangle.ts
+++ b/src/commands/rectangle.ts
@@ -104,8 +104,9 @@ abstract class EditRectangle extends RectangleKillYankCommand {
       revealPrimaryActive(textEditor);
 
       this.emacsController.exitMarkMode();
-      makeSelectionsEmpty(textEditor);
     }
+
+    makeSelectionsEmpty(textEditor);
   }
 }
 

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -16,7 +16,7 @@ export class RegisterCommandState {
   public startAcceptingRegisterKey(commandType: RegisterCommandType, message: string): void {
     this._acceptingRegisterCommand = commandType;
     vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRectCommand", false);
-    vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRegisterKey", true);
+    vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRegisterCommand", true);
 
     MessageManager.showMessage(message);
   }
@@ -24,7 +24,7 @@ export class RegisterCommandState {
   public stopAcceptingRegisterKey(): void {
     if (this._acceptingRegisterCommand) {
       this._acceptingRegisterCommand = null;
-      vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRegisterKey", false);
+      vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRegisterCommand", false);
     }
   }
 }

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -130,18 +130,18 @@ export class InsertRegister extends EmacsCommand {
     prefixArgument: number | undefined,
     args?: unknown[],
   ): Promise<void> {
-    const arg = args?.[0];
-    if (typeof arg !== "string") {
+    const registerKey = args?.[0];
+    if (typeof registerKey !== "string") {
       return;
     }
 
-    if (!this.textRegisters.has(arg)) {
+    if (!this.textRegisters.has(registerKey)) {
       MessageManager.showMessage("Register does not contain text");
       // TODO: Exit the inRegisterInsertMode.
       return;
     }
 
-    const textToInsert = this.textRegisters.get(arg);
+    const textToInsert = this.textRegisters.get(registerKey);
     if (textToInsert == undefined) {
       return;
     }

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -137,6 +137,10 @@ export class RegisterCommand extends EmacsCommand {
 
   // insert-register, C-x r i <r>
   public async runInsert(textEditor: vscode.TextEditor, registerKey: string): Promise<void> {
+    const selections = textEditor.selections;
+
+    this.emacsController.pushMark(selections.map((s) => s.active));
+
     if (!this.textRegisters.has(registerKey)) {
       MessageManager.showMessage("Register does not contain text");
       return;
@@ -146,10 +150,6 @@ export class RegisterCommand extends EmacsCommand {
     if (textToInsert == undefined) {
       return;
     }
-    // Looking for how to insert-replace with selections highlighted.... must copy-paste from Yank command
-    const selections = textEditor.selections;
-
-    this.emacsController.pushMark(selections.map((s) => s.active));
 
     await textEditor.edit((editBuilder) => {
       selections.forEach((selection) => {
@@ -160,5 +160,7 @@ export class RegisterCommand extends EmacsCommand {
         editBuilder.insert(selection.start, textToInsert);
       });
     });
+
+    MessageManager.showMessage("Mark set");
   }
 }

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -136,6 +136,8 @@ export class InsertRegister extends EmacsCommand {
     }
 
     if (!this.textRegisters.has(arg)) {
+      MessageManager.showMessage("Register does not contain text");
+      // TODO: Exit the inRegisterInsertMode.
       return;
     }
 

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -4,6 +4,8 @@ import { MessageManager } from "../message";
 import { EmacsCommand, ITextEditorInterruptionHandler } from ".";
 import { getNonEmptySelections, makeSelectionsEmpty } from "./helpers/selection";
 
+export type TextRegisters = Map<string, string>;
+
 // Will bind this this to C-x r s
 export class StartRegisterCopyCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
   public readonly id = "startRegisterCopyCommand";
@@ -69,7 +71,7 @@ export class CopyToRegister extends EmacsCommand {
 
   constructor(
     emacsController: IEmacsController,
-    private readonly textRegister: Map<string, string>,
+    private readonly textRegisters: TextRegisters,
   ) {
     super(emacsController);
   }
@@ -105,7 +107,7 @@ export class CopyToRegister extends EmacsCommand {
       i++;
     }
 
-    this.textRegister.set(registerKey, combinedText);
+    this.textRegisters.set(registerKey, combinedText);
     // After copying the selection, get out of mark mode and de-select the selections
     this.emacsController.exitMarkMode();
     makeSelectionsEmpty(textEditor);
@@ -117,7 +119,7 @@ export class InsertRegister extends EmacsCommand {
 
   constructor(
     emacsController: IEmacsController,
-    private readonly textRegister: Map<string, string>,
+    private readonly textRegisters: TextRegisters,
   ) {
     super(emacsController);
   }
@@ -133,11 +135,11 @@ export class InsertRegister extends EmacsCommand {
       return;
     }
 
-    if (!this.textRegister.has(arg)) {
+    if (!this.textRegisters.has(arg)) {
       return;
     }
 
-    const textToInsert = this.textRegister.get(arg);
+    const textToInsert = this.textRegisters.get(arg);
     if (textToInsert == undefined) {
       return;
     }

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -35,17 +35,17 @@ export class PreCopyToRegister extends EmacsCommand implements ITextEditorInterr
 
   constructor(
     emacsController: IEmacsController,
-    private readonly registerCommandSequenceState: RegisterCommandState,
+    private readonly registerCommandState: RegisterCommandState,
   ) {
     super(emacsController);
   }
 
   public run(): void {
-    this.registerCommandSequenceState.startAcceptingRegisterKey("copy", "Copy to register: ");
+    this.registerCommandState.startAcceptingRegisterKey("copy", "Copy to register: ");
   }
 
   public onDidInterruptTextEditor(): void {
-    this.registerCommandSequenceState.stopAcceptingRegisterKey();
+    this.registerCommandState.stopAcceptingRegisterKey();
   }
 }
 
@@ -55,17 +55,17 @@ export class PreInsertRegister extends EmacsCommand implements ITextEditorInterr
 
   constructor(
     emacsController: IEmacsController,
-    private readonly registerCommandSequenceState: RegisterCommandState,
+    private readonly registerCommandState: RegisterCommandState,
   ) {
     super(emacsController);
   }
 
   public run(): void {
-    this.registerCommandSequenceState.startAcceptingRegisterKey("insert", "Insert from register: ");
+    this.registerCommandState.startAcceptingRegisterKey("insert", "Insert from register: ");
   }
 
   public onDidInterruptTextEditor(): void {
-    this.registerCommandSequenceState.stopAcceptingRegisterKey();
+    this.registerCommandState.stopAcceptingRegisterKey();
   }
 }
 
@@ -76,7 +76,7 @@ export class RegisterCommand extends EmacsCommand {
   constructor(
     emacsController: IEmacsController,
     private readonly textRegisters: TextRegisters,
-    private readonly registerCommandSequenceState: RegisterCommandState,
+    private readonly registerCommandState: RegisterCommandState,
   ) {
     super(emacsController);
   }
@@ -92,12 +92,12 @@ export class RegisterCommand extends EmacsCommand {
       return;
     }
 
-    if (!this.registerCommandSequenceState.acceptingRegisterCommand) {
+    const commandType = this.registerCommandState.acceptingRegisterCommand;
+    if (!commandType) {
       return;
     }
 
-    const commandType = this.registerCommandSequenceState.acceptingRegisterCommand;
-    this.registerCommandSequenceState.stopAcceptingRegisterKey();
+    this.registerCommandState.stopAcceptingRegisterKey();
 
     if (commandType === "copy") {
       return this.runCopy(textEditor, registerKey);

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -71,8 +71,8 @@ export class PreInsertRegister extends EmacsCommand implements ITextEditorInterr
 }
 
 // Will be bound to all characters (a, b, c, ...) following the commands above (C-x r s, C-x r i) making use of the acceptingRegisterKey context.
-export class RegisterCommand extends EmacsCommand {
-  public readonly id = "registerCommand";
+export class SomeRegisterCommand extends EmacsCommand {
+  public readonly id = "someRegisterCommand";
 
   constructor(
     emacsController: IEmacsController,

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -80,8 +80,8 @@ export class CopyToRegister extends EmacsCommand {
     prefixArgument: number | undefined,
     args?: unknown[],
   ): void | Thenable<void> {
-    const arg = args?.[0];
-    if (typeof arg !== "string") {
+    const registerKey = args?.[0];
+    if (typeof registerKey !== "string") {
       return;
     }
 
@@ -99,18 +99,13 @@ export class CopyToRegister extends EmacsCommand {
     // selections is now a list of non empty selections, iterate through them and
     // build a single variable combinedtext
     let i = 0;
-    let combinedtext = "";
+    let combinedText = "";
     while (i < selections.length) {
-      combinedtext = combinedtext + textEditor.document.getText(selections[i]);
+      combinedText = combinedText + textEditor.document.getText(selections[i]);
       i++;
     }
 
-    const register_string = arg;
-    if (register_string == null) {
-      return;
-    }
-
-    this.textRegister.set(register_string, combinedtext);
+    this.textRegister.set(registerKey, combinedText);
     // After copying the selection, get out of mark mode and de-select the selections
     this.emacsController.exitMarkMode();
     makeSelectionsEmpty(textEditor);

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -30,8 +30,8 @@ export class RegisterCommandState {
 }
 
 // Will be bound to C-x r s
-export class StartRegisterCopyCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
-  public readonly id = "startRegisterCopyCommand";
+export class PreCopyToRegister extends EmacsCommand implements ITextEditorInterruptionHandler {
+  public readonly id = "preCopyToRegister";
 
   constructor(
     emacsController: IEmacsController,
@@ -50,8 +50,8 @@ export class StartRegisterCopyCommand extends EmacsCommand implements ITextEdito
 }
 
 // Will be bound to C-x r i
-export class StartRegisterInsertCommand extends EmacsCommand implements ITextEditorInterruptionHandler {
-  public readonly id = "startRegisterInsertCommand";
+export class PreInsertRegister extends EmacsCommand implements ITextEditorInterruptionHandler {
+  public readonly id = "preInsertRegister";
 
   constructor(
     emacsController: IEmacsController,

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -120,17 +120,12 @@ export class SomeRegisterCommand extends EmacsCommand {
     if (selectionsAfterRectDisabled) {
       textEditor.selections = selectionsAfterRectDisabled;
     }
-    // selections is now a list of non empty selections, iterate through them and
-    // build a single variable combinedtext
-    let i = 0;
-    let combinedText = "";
-    while (i < selections.length) {
-      combinedText = combinedText + textEditor.document.getText(selections[i]);
-      i++;
-    }
 
-    this.textRegisters.set(registerKey, combinedText);
-    // After copying the selection, get out of mark mode and de-select the selections
+    const texts = selections.map((selection) => textEditor.document.getText(selection));
+    const text = texts.join(""); // TODO: Deal with the multi-cursor case like the kill-yank commands.
+
+    this.textRegisters.set(registerKey, text);
+
     this.emacsController.exitMarkMode();
     makeSelectionsEmpty(textEditor);
   }

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -25,6 +25,7 @@ export class RegisterCommandState {
     if (this._acceptingRegisterCommand) {
       this._acceptingRegisterCommand = null;
       vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingRegisterCommand", false);
+      MessageManager.removeMessage();
     }
   }
 }
@@ -87,17 +88,17 @@ export class RegisterCommand extends EmacsCommand {
     prefixArgument: number | undefined,
     args?: unknown[],
   ): void | Thenable<void> {
-    const registerKey = args?.[0];
-    if (typeof registerKey !== "string") {
-      return;
-    }
-
     const commandType = this.registerCommandState.acceptingRegisterCommand;
     if (!commandType) {
       return;
     }
 
     this.registerCommandState.stopAcceptingRegisterKey();
+
+    const registerKey = args?.[0];
+    if (typeof registerKey !== "string") {
+      return;
+    }
 
     if (commandType === "copy") {
       return this.runCopy(textEditor, registerKey);

--- a/src/emulator-map.ts
+++ b/src/emulator-map.ts
@@ -1,19 +1,20 @@
 import { TextEditor } from "vscode";
 import { EmacsEmulator } from "./emulator";
 import { KillRing } from "./kill-yank/kill-ring";
+import type { TextRegisters } from "./commands/registers";
 import { Minibuffer } from "./minibuffer";
 
 export class EmacsEmulatorMap {
   private emacsEmulatorMap: Map<string, EmacsEmulator>;
   private killRing: KillRing;
   private minibuffer: Minibuffer;
-  private textRegister: Map<string, string>;
+  private textRegisters: TextRegisters;
 
-  constructor(killRing: KillRing, minibuffer: Minibuffer, textRegister: Map<string, string>) {
+  constructor(killRing: KillRing, minibuffer: Minibuffer, textRegisters: TextRegisters) {
     this.emacsEmulatorMap = new Map();
     this.killRing = killRing;
     this.minibuffer = minibuffer;
-    this.textRegister = textRegister;
+    this.textRegisters = textRegisters;
   }
 
   public getOrCreate(editor: TextEditor): [EmacsEmulator, boolean] {
@@ -24,7 +25,7 @@ export class EmacsEmulatorMap {
 
     if (!emacsEmulator) {
       isNew = true;
-      emacsEmulator = new EmacsEmulator(editor, this.killRing, this.minibuffer, this.textRegister);
+      emacsEmulator = new EmacsEmulator(editor, this.killRing, this.minibuffer, this.textRegisters);
       this.emacsEmulatorMap.set(editorId, emacsEmulator);
     } else {
       emacsEmulator.setTextEditor(editor);

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -219,8 +219,8 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.registerDisposable(killYanker);
 
     const registerCommandState = new TextRegisterCommands.RegisterCommandState();
-    this.commandRegistry.register(new TextRegisterCommands.StartRegisterCopyCommand(this, registerCommandState));
-    this.commandRegistry.register(new TextRegisterCommands.StartRegisterInsertCommand(this, registerCommandState));
+    this.commandRegistry.register(new TextRegisterCommands.PreCopyToRegister(this, registerCommandState));
+    this.commandRegistry.register(new TextRegisterCommands.PreInsertRegister(this, registerCommandState));
     this.commandRegistry.register(new TextRegisterCommands.RegisterCommand(this, textRegisters, registerCommandState));
 
     const rectangleState: RectangleCommands.RectangleState = {

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -138,7 +138,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     textEditor: TextEditor,
     killRing: KillRing | null = null,
     minibuffer: Minibuffer = new InputBoxMinibuffer(),
-    textRegister: Map<string, string> = new Map(),
+    textRegisters: TextRegisterCommands.TextRegisters = new Map(),
   ) {
     this._textEditor = textEditor;
 
@@ -220,8 +220,8 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
 
     this.commandRegistry.register(new TextRegisterCommands.StartRegisterCopyCommand(this));
     this.commandRegistry.register(new TextRegisterCommands.StartRegisterInsertCommand(this));
-    this.commandRegistry.register(new TextRegisterCommands.CopyToRegister(this, textRegister));
-    this.commandRegistry.register(new TextRegisterCommands.InsertRegister(this, textRegister));
+    this.commandRegistry.register(new TextRegisterCommands.CopyToRegister(this, textRegisters));
+    this.commandRegistry.register(new TextRegisterCommands.InsertRegister(this, textRegisters));
 
     const rectangleState: RectangleCommands.RectangleState = {
       latestKilledRectangle: [],

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -218,10 +218,10 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     this.killYanker = killYanker;
     this.registerDisposable(killYanker);
 
-    this.commandRegistry.register(new TextRegisterCommands.StartRegisterCopyCommand(this));
-    this.commandRegistry.register(new TextRegisterCommands.StartRegisterInsertCommand(this));
-    this.commandRegistry.register(new TextRegisterCommands.CopyToRegister(this, textRegisters));
-    this.commandRegistry.register(new TextRegisterCommands.InsertRegister(this, textRegisters));
+    const registerCommandState = new TextRegisterCommands.RegisterCommandState();
+    this.commandRegistry.register(new TextRegisterCommands.StartRegisterCopyCommand(this, registerCommandState));
+    this.commandRegistry.register(new TextRegisterCommands.StartRegisterInsertCommand(this, registerCommandState));
+    this.commandRegistry.register(new TextRegisterCommands.RegisterCommand(this, textRegisters, registerCommandState));
 
     const rectangleState: RectangleCommands.RectangleState = {
       latestKilledRectangle: [],

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -221,7 +221,9 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     const registerCommandState = new TextRegisterCommands.RegisterCommandState();
     this.commandRegistry.register(new TextRegisterCommands.PreCopyToRegister(this, registerCommandState));
     this.commandRegistry.register(new TextRegisterCommands.PreInsertRegister(this, registerCommandState));
-    this.commandRegistry.register(new TextRegisterCommands.RegisterCommand(this, textRegisters, registerCommandState));
+    this.commandRegistry.register(
+      new TextRegisterCommands.SomeRegisterCommand(this, textRegisters, registerCommandState),
+    );
 
     const rectangleState: RectangleCommands.RectangleState = {
       latestKilledRectangle: [],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -371,12 +371,8 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("startRegisterInsertCommand");
   });
 
-  registerEmulatorCommand("emacs-mcx.copyToRegister", (emulator, ...args) => {
-    return emulator.runCommand("copyToRegister", args);
-  });
-
-  registerEmulatorCommand("emacs-mcx.insertRegister", (emulator, ...args) => {
-    return emulator.runCommand("insertRegister", args);
+  registerEmulatorCommand("emacs-mcx.registerCommand", (emulator, ...args) => {
+    return emulator.runCommand("registerCommand", args);
   });
 
   registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, arg0) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -371,8 +371,8 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("preInsertRegister");
   });
 
-  registerEmulatorCommand("emacs-mcx.registerCommand", (emulator, ...args) => {
-    return emulator.runCommand("registerCommand", args);
+  registerEmulatorCommand("emacs-mcx.someRegisterCommand", (emulator, ...args) => {
+    return emulator.runCommand("someRegisterCommand", args);
   });
 
   registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, arg0) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -363,12 +363,12 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("paredit.backwardKillSexp");
   });
 
-  registerEmulatorCommand("emacs-mcx.startRegisterCopyCommand", (emulator) => {
-    return emulator.runCommand("startRegisterCopyCommand");
+  registerEmulatorCommand("emacs-mcx.preCopyToRegister", (emulator) => {
+    return emulator.runCommand("preCopyToRegister");
   });
 
-  registerEmulatorCommand("emacs-mcx.startRegisterInsertCommand", (emulator) => {
-    return emulator.runCommand("startRegisterInsertCommand");
+  registerEmulatorCommand("emacs-mcx.preInsertRegister", (emulator) => {
+    return emulator.runCommand("preInsertRegister");
   });
 
   registerEmulatorCommand("emacs-mcx.registerCommand", (emulator, ...args) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { moveCommandIds } from "./commands/move";
+import type { TextRegisters } from "./commands/registers";
 import { Configuration } from "./configuration/configuration";
 import { WorkspaceConfigCache } from "./workspace-configuration";
 import { EmacsEmulator } from "./emulator";
@@ -17,9 +18,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
   const killRing = new KillRing(Configuration.instance.killRingMax);
   const minibuffer = new InputBoxMinibuffer();
-  const textRegister = new Map<string, string>();
+  const textRegisters: TextRegisters = new Map();
 
-  const emulatorMap = new EmacsEmulatorMap(killRing, minibuffer, textRegister);
+  const emulatorMap = new EmacsEmulatorMap(killRing, minibuffer, textRegisters);
 
   function getAndUpdateEmulator() {
     const activeTextEditor = vscode.window.activeTextEditor;

--- a/src/message.ts
+++ b/src/message.ts
@@ -20,15 +20,11 @@ export class MessageManager implements vscode.Disposable {
   }
 
   public static showMessage(text: string): void {
-    if (this.instance) {
-      this.instance.showMessage(text);
-    }
+    this.instance.showMessage(text);
   }
 
   public static removeMessage(): void {
-    if (this.instance) {
-      this.instance.removeMessage();
-    }
+    this.instance.removeMessage();
   }
 
   private static inst: MessageManager;

--- a/src/message.ts
+++ b/src/message.ts
@@ -25,6 +25,12 @@ export class MessageManager implements vscode.Disposable {
     }
   }
 
+  public static removeMessage(): void {
+    if (this.instance) {
+      this.instance.removeMessage();
+    }
+  }
+
   private static inst: MessageManager;
 
   private timeout: number;
@@ -71,6 +77,12 @@ export class MessageManager implements vscode.Disposable {
       this.messageDisposable.dispose();
     }
     this.messageDisposable = vscode.window.setStatusBarMessage(text, this.timeout);
+  }
+
+  public removeMessage(): void {
+    if (this.messageDisposable !== null) {
+      this.messageDisposable.dispose();
+    }
   }
 
   public dispose(): void {

--- a/src/test/suite/commands/rectangle.test.ts
+++ b/src/test/suite/commands/rectangle.test.ts
@@ -148,7 +148,7 @@ KLMNOPQRST`,
     activeTextEditor.selections = [new vscode.Selection(0, 3, 2, 7)];
     await emulator.runCommand("copyRectangleAsKill");
     assertTextEqual(activeTextEditor, initialText);
-    assert.deepStrictEqual(activeTextEditor.selections, [new vscode.Selection(0, 3, 2, 7)]); // The selection is not changed
+    assertCursorsEqual(activeTextEditor, [2, 7]);
 
     setEmptyCursors(activeTextEditor, [0, 0]);
     await emulator.runCommand("yankRectangle");

--- a/src/test/suite/commands/rectangle.test.ts
+++ b/src/test/suite/commands/rectangle.test.ts
@@ -149,6 +149,7 @@ KLMNOPQRST`,
     await emulator.runCommand("copyRectangleAsKill");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [2, 7]);
+    assert.equal(emulator.isInMarkMode, false);
 
     setEmptyCursors(activeTextEditor, [0, 0]);
     await emulator.runCommand("yankRectangle");

--- a/src/test/suite/text-register.test.ts
+++ b/src/test/suite/text-register.test.ts
@@ -19,27 +19,27 @@ suite("Text registers", () => {
   test("copy and paste", async () => {
     activeTextEditor.selections = [new vscode.Selection(0, 0, 1, 2)];
     await emulator.runCommand("preCopyToRegister");
-    await emulator.runCommand("registerCommand", ["a"]);
+    await emulator.runCommand("someRegisterCommand", ["a"]);
 
     // Empty string
     activeTextEditor.selections = [new vscode.Selection(0, 0, 0, 0)];
     await emulator.runCommand("preCopyToRegister");
-    await emulator.runCommand("registerCommand", ["b"]);
+    await emulator.runCommand("someRegisterCommand", ["b"]);
 
     await clearTextEditor(activeTextEditor);
 
     await emulator.runCommand("preInsertRegister");
-    await emulator.runCommand("registerCommand", ["c"]);
+    await emulator.runCommand("someRegisterCommand", ["c"]);
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
     await emulator.runCommand("preInsertRegister");
-    await emulator.runCommand("registerCommand", ["b"]);
+    await emulator.runCommand("someRegisterCommand", ["b"]);
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
     await emulator.runCommand("preInsertRegister");
-    await emulator.runCommand("registerCommand", ["a"]);
+    await emulator.runCommand("someRegisterCommand", ["a"]);
     assertTextEqual(activeTextEditor, "0123456789\nab");
     assertCursorsEqual(activeTextEditor, [1, 2]);
   });

--- a/src/test/suite/text-register.test.ts
+++ b/src/test/suite/text-register.test.ts
@@ -18,23 +18,28 @@ suite("Text registers", () => {
 
   test("copy and paste", async () => {
     activeTextEditor.selections = [new vscode.Selection(0, 0, 1, 2)];
-    await emulator.runCommand("copyToRegister", ["a"]);
+    await emulator.runCommand("preCopyToRegister");
+    await emulator.runCommand("registerCommand", ["a"]);
 
     // Empty string
     activeTextEditor.selections = [new vscode.Selection(0, 0, 0, 0)];
-    await emulator.runCommand("copyToRegister", ["b"]);
+    await emulator.runCommand("preCopyToRegister");
+    await emulator.runCommand("registerCommand", ["b"]);
 
     await clearTextEditor(activeTextEditor);
 
-    await emulator.runCommand("insertRegister", ["c"]);
+    await emulator.runCommand("preInsertRegister");
+    await emulator.runCommand("registerCommand", ["c"]);
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
-    await emulator.runCommand("insertRegister", ["b"]);
+    await emulator.runCommand("preInsertRegister");
+    await emulator.runCommand("registerCommand", ["b"]);
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
-    await emulator.runCommand("insertRegister", ["a"]);
+    await emulator.runCommand("preInsertRegister");
+    await emulator.runCommand("registerCommand", ["a"]);
     assertTextEqual(activeTextEditor, "0123456789\nab");
     assertCursorsEqual(activeTextEditor, [1, 2]);
   });


### PR DESCRIPTION
* Refactoring
* Fix the internal context name to manage the `C-x r -` command sequence state.
* Fix `copyToRegister` to deactivate mark-mode and selections.