### PR TITLE
Add untrusted workspace support for enhanced security

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
   "extensionKind": [
     "ui"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "main": "./dist/extension.js",
   "browser": "./dist/web/extension.js",
   "contributes": {


### PR DESCRIPTION
This extension is safe to run in VSCode's Restriction Mode because:
- Only manipulates text within editor buffers (no file system access)
- Uses built-in VSCode APIs exclusively (no external process execution)
- No network requests or workspace folder access
- No dynamic code execution or sensitive operations
- All functionality confined to text editing and navigation commands

🤖 Generated with [Claude Code](https://claude.ai/code)


-> https://code.visualstudio.com/api/extension-guides/workspace-trust