### PR TITLE
Revert "Revert "Remove !config.emacs-mcx.useMetaPrefixMacCmd from the default meta keybindings so that they are always enabled""

### DIFF
--- a/keybinding-generator/generate-keybindings.mts
+++ b/keybinding-generator/generate-keybindings.mts
@@ -123,7 +123,7 @@ function compileKeybinding(opts: { key: string; command?: string; when?: string;
     keybindings.push({
       key: replaceAll(key, "meta", "alt"),
       command,
-      when: addWhenCond(when, "!config.emacs-mcx.useMetaPrefixMacCmd"),
+      ...(when ? { when } : {}),
       ...(args ? { args } : {}),
     });
 

--- a/keybinding-generator/generate-keybindings.test.mts
+++ b/keybinding-generator/generate-keybindings.test.mts
@@ -38,7 +38,6 @@ describe("generateKeybindings", () => {
       {
         key: "alt+f",
         command: "emacs-mcx.forwardWord",
-        when: "!config.emacs-mcx.useMetaPrefixMacCmd",
       },
       {
         mac: "cmd+f",
@@ -69,7 +68,7 @@ describe("generateKeybindings", () => {
       {
         key: "alt+f",
         command: "emacs-mcx.forwardWord",
-        when: "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd",
+        when: "editorTextFocus",
       },
       {
         mac: "cmd+f",
@@ -99,7 +98,6 @@ describe("generateKeybindings", () => {
       {
         key: "alt+f",
         command: "emacs-mcx.forwardWord",
-        when: "!config.emacs-mcx.useMetaPrefixMacCmd",
       },
       {
         mac: "cmd+f",
@@ -119,7 +117,6 @@ describe("generateKeybindings", () => {
       {
         key: "alt+j",
         command: "emacs-mcx.forwardWord",
-        when: "!config.emacs-mcx.useMetaPrefixMacCmd",
       },
       {
         mac: "cmd+j",
@@ -149,7 +146,6 @@ describe("generateKeybindings", () => {
       {
         key: "alt+f alt+f",
         command: "emacs-mcx.forwardWord",
-        when: "!config.emacs-mcx.useMetaPrefixMacCmd",
       },
       {
         mac: "cmd+f cmd+f",

--- a/package.json
+++ b/package.json
@@ -419,7 +419,7 @@
       {
         "key": "alt+0",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           0
         ]
@@ -451,7 +451,7 @@
       {
         "key": "alt+0",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           0
         ]
@@ -499,7 +499,7 @@
       {
         "key": "alt+1",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           1
         ]
@@ -531,7 +531,7 @@
       {
         "key": "alt+1",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           1
         ]
@@ -579,7 +579,7 @@
       {
         "key": "alt+2",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           2
         ]
@@ -611,7 +611,7 @@
       {
         "key": "alt+2",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           2
         ]
@@ -659,7 +659,7 @@
       {
         "key": "alt+3",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           3
         ]
@@ -691,7 +691,7 @@
       {
         "key": "alt+3",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           3
         ]
@@ -739,7 +739,7 @@
       {
         "key": "alt+4",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           4
         ]
@@ -771,7 +771,7 @@
       {
         "key": "alt+4",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           4
         ]
@@ -819,7 +819,7 @@
       {
         "key": "alt+5",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           5
         ]
@@ -851,7 +851,7 @@
       {
         "key": "alt+5",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           5
         ]
@@ -899,7 +899,7 @@
       {
         "key": "alt+6",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           6
         ]
@@ -931,7 +931,7 @@
       {
         "key": "alt+6",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           6
         ]
@@ -979,7 +979,7 @@
       {
         "key": "alt+7",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           7
         ]
@@ -1011,7 +1011,7 @@
       {
         "key": "alt+7",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           7
         ]
@@ -1059,7 +1059,7 @@
       {
         "key": "alt+8",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           8
         ]
@@ -1091,7 +1091,7 @@
       {
         "key": "alt+8",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           8
         ]
@@ -1139,7 +1139,7 @@
       {
         "key": "alt+9",
         "command": "emacs-mcx.subsequentArgumentDigit",
-        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           9
         ]
@@ -1171,7 +1171,7 @@
       {
         "key": "alt+9",
         "command": "emacs-mcx.digitArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && config.emacs-mcx.enableDigitArgument",
         "args": [
           9
         ]
@@ -1211,7 +1211,7 @@
       {
         "key": "alt+-",
         "command": "emacs-mcx.negativeArgument",
-        "when": "!emacs-mcx.acceptingArgument && editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "!emacs-mcx.acceptingArgument && editorTextFocus"
       },
       {
         "mac": "cmd+-",
@@ -1969,7 +1969,7 @@
       {
         "key": "alt+f",
         "command": "emacs-mcx.forwardWord",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+f",
@@ -1989,7 +1989,7 @@
       {
         "key": "alt+f",
         "command": "emacs-mcx.isearchExit",
-        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.forwardWord"
         }
@@ -2021,7 +2021,7 @@
       {
         "key": "alt+b",
         "command": "emacs-mcx.backwardWord",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+b",
@@ -2041,7 +2041,7 @@
       {
         "key": "alt+b",
         "command": "emacs-mcx.isearchExit",
-        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.backwardWord"
         }
@@ -2078,7 +2078,7 @@
       {
         "key": "alt+right",
         "command": "emacs-mcx.forwardWord",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+right",
@@ -2106,7 +2106,7 @@
       {
         "key": "alt+right",
         "command": "emacs-mcx.isearchExit",
-        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.forwardWord"
         }
@@ -2143,7 +2143,7 @@
       {
         "key": "alt+left",
         "command": "emacs-mcx.backwardWord",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+left",
@@ -2171,7 +2171,7 @@
       {
         "key": "alt+left",
         "command": "emacs-mcx.isearchExit",
-        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.backwardWord"
         }
@@ -2203,7 +2203,7 @@
       {
         "key": "alt+m",
         "command": "emacs-mcx.backToIndentation",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+m",
@@ -2223,7 +2223,7 @@
       {
         "key": "alt+m",
         "command": "emacs-mcx.isearchExit",
-        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "!config.emacs-mcx.cursorMoveOnFindWidget && editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.backToIndentation"
         }
@@ -2286,7 +2286,7 @@
       {
         "key": "alt+v",
         "command": "emacs-mcx.scrollDownCommand",
-        "when": "editorTextFocus && !suggestWidgetVisible && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !suggestWidgetVisible"
       },
       {
         "mac": "cmd+v",
@@ -2314,7 +2314,7 @@
       {
         "key": "alt+v",
         "command": "emacs-mcx.isearchExit",
-        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.scrollDownCommand"
         }
@@ -2338,7 +2338,7 @@
       {
         "key": "alt+shift+[",
         "command": "emacs-mcx.backwardParagraph",
-        "when": "editorTextFocus && !suggestWidgetVisible && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !suggestWidgetVisible"
       },
       {
         "mac": "cmd+shift+[",
@@ -2363,7 +2363,7 @@
       {
         "key": "alt+shift+]",
         "command": "emacs-mcx.forwardParagraph",
-        "when": "editorTextFocus && !suggestWidgetVisible && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !suggestWidgetVisible"
       },
       {
         "mac": "cmd+shift+]",
@@ -2388,7 +2388,7 @@
       {
         "key": "alt+shift+.",
         "command": "emacs-mcx.endOfBuffer",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+shift+.",
@@ -2408,7 +2408,7 @@
       {
         "key": "alt+shift+.",
         "command": "emacs-mcx.isearchExit",
-        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.endOfBuffer"
         }
@@ -2440,7 +2440,7 @@
       {
         "key": "alt+shift+,",
         "command": "emacs-mcx.beginningOfBuffer",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+shift+,",
@@ -2460,7 +2460,7 @@
       {
         "key": "alt+shift+,",
         "command": "emacs-mcx.isearchExit",
-        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.beginningOfBuffer"
         }
@@ -2492,7 +2492,7 @@
       {
         "key": "alt+r",
         "command": "emacs-mcx.moveToWindowLineTopBottom",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+r",
@@ -2512,7 +2512,7 @@
       {
         "key": "alt+g alt+g",
         "command": "emacs-mcx.gotoLine",
-        "when": "!terminalFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "!terminalFocus"
       },
       {
         "mac": "cmd+g cmd+g",
@@ -2522,7 +2522,7 @@
       {
         "key": "alt+g g",
         "command": "emacs-mcx.gotoLine",
-        "when": "!terminalFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "!terminalFocus"
       },
       {
         "mac": "cmd+g g",
@@ -2532,7 +2532,7 @@
       {
         "key": "alt+g alt+g",
         "command": "emacs-mcx.isearchExit",
-        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.gotoLine"
         }
@@ -2548,7 +2548,7 @@
       {
         "key": "alt+g g",
         "command": "emacs-mcx.isearchExit",
-        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "emacs-mcx.gotoLine"
         }
@@ -2569,7 +2569,7 @@
       {
         "key": "alt+g n",
         "command": "editor.action.marker.next",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+g n",
@@ -2579,7 +2579,7 @@
       {
         "key": "alt+g alt+n",
         "command": "editor.action.marker.next",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+g cmd+n",
@@ -2594,7 +2594,7 @@
       {
         "key": "alt+g p",
         "command": "editor.action.marker.prev",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+g p",
@@ -2604,7 +2604,7 @@
       {
         "key": "alt+g alt+p",
         "command": "editor.action.marker.prev",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+g cmd+p",
@@ -2649,7 +2649,7 @@
       {
         "key": "ctrl+alt+s",
         "command": "emacs-mcx.isearchForwardRegexp",
-        "when": "!findInputFocussed && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "!findInputFocussed"
       },
       {
         "mac": "ctrl+cmd+s",
@@ -2669,7 +2669,7 @@
       {
         "key": "ctrl+alt+s",
         "command": "editor.action.nextMatchFindAction",
-        "when": "findInputFocussed && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "findInputFocussed"
       },
       {
         "mac": "ctrl+cmd+s",
@@ -2689,7 +2689,7 @@
       {
         "key": "ctrl+alt+r",
         "command": "emacs-mcx.isearchBackwardRegexp",
-        "when": "!findInputFocussed && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "!findInputFocussed"
       },
       {
         "mac": "ctrl+cmd+r",
@@ -2709,7 +2709,7 @@
       {
         "key": "ctrl+alt+r",
         "command": "editor.action.previousMatchFindAction",
-        "when": "findInputFocussed && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "findInputFocussed"
       },
       {
         "mac": "ctrl+cmd+r",
@@ -2729,7 +2729,7 @@
       {
         "key": "alt+shift+5",
         "command": "emacs-mcx.queryReplace",
-        "when": "editorFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorFocus"
       },
       {
         "mac": "cmd+shift+5",
@@ -2749,7 +2749,7 @@
       {
         "key": "ctrl+alt+shift+5",
         "command": "emacs-mcx.queryReplaceRegexp",
-        "when": "editorFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorFocus"
       },
       {
         "mac": "ctrl+cmd+shift+5",
@@ -2988,8 +2988,7 @@
       },
       {
         "key": "alt+s o",
-        "command": "workbench.action.quickTextSearch",
-        "when": "!config.emacs-mcx.useMetaPrefixMacCmd"
+        "command": "workbench.action.quickTextSearch"
       },
       {
         "mac": "cmd+s o",
@@ -2999,7 +2998,7 @@
       {
         "key": "ctrl+alt+n",
         "command": "emacs-mcx.addSelectionToNextFindMatch",
-        "when": "editorFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorFocus"
       },
       {
         "mac": "ctrl+cmd+n",
@@ -3019,7 +3018,7 @@
       {
         "key": "ctrl+alt+p",
         "command": "emacs-mcx.addSelectionToPreviousFindMatch",
-        "when": "editorFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorFocus"
       },
       {
         "mac": "ctrl+cmd+p",
@@ -3049,7 +3048,7 @@
       {
         "key": "alt+\\",
         "command": "emacs-mcx.deleteHorizontalSpace",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+\\",
@@ -3069,7 +3068,7 @@
       {
         "key": "alt+d",
         "command": "emacs-mcx.killWord",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+d",
@@ -3089,7 +3088,7 @@
       {
         "key": "alt+backspace",
         "command": "emacs-mcx.backwardKillWord",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+backspace",
@@ -3124,7 +3123,7 @@
       {
         "key": "alt+w",
         "command": "emacs-mcx.copyRegion",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+w",
@@ -3154,7 +3153,7 @@
       {
         "key": "alt+y",
         "command": "emacs-mcx.yank-pop",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+y",
@@ -3280,7 +3279,7 @@
       {
         "key": "alt+;",
         "command": "editor.action.blockComment",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+;",
@@ -3300,7 +3299,7 @@
       {
         "key": "alt+;",
         "command": "emacs-mcx.isearchExit",
-        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing && !config.emacs-mcx.useMetaPrefixMacCmd",
+        "when": "editorFocus && findWidgetVisible && !replaceInputFocussed && !isComposing",
         "args": {
           "then": "editor.action.blockComment"
         }
@@ -3337,7 +3336,7 @@
       {
         "key": "alt+l",
         "command": "emacs-mcx.transformToLowercase",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+l",
@@ -3362,7 +3361,7 @@
       {
         "key": "alt+u",
         "command": "emacs-mcx.transformToUppercase",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+u",
@@ -3382,7 +3381,7 @@
       {
         "key": "alt+c",
         "command": "emacs-mcx.transformToTitlecase",
-        "when": "editorTextFocus && !editorReadonly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadonly"
       },
       {
         "mac": "cmd+c",
@@ -3402,7 +3401,7 @@
       {
         "key": "alt+shift+6",
         "command": "emacs-mcx.deleteIndentation",
-        "when": "editorTextFocus && !editorReadOnly && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && !editorReadOnly"
       },
       {
         "mac": "cmd+shift+6",
@@ -4181,7 +4180,7 @@
       {
         "key": "alt+w",
         "command": "emacs-mcx.copyRectangleAsKill",
-        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "emacs-mcx.acceptingRectCommand && editorTextFocus"
       },
       {
         "mac": "cmd+w",
@@ -4815,7 +4814,7 @@
       {
         "key": "alt+/",
         "command": "editor.action.triggerSuggest",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "cmd+/",
@@ -4835,7 +4834,7 @@
       {
         "key": "alt+/",
         "command": "toggleSuggestionDetails",
-        "when": "editorTextFocus && suggestWidgetVisible && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus && suggestWidgetVisible"
       },
       {
         "mac": "cmd+/",
@@ -4854,8 +4853,7 @@
       },
       {
         "key": "alt+x",
-        "command": "workbench.action.showCommands",
-        "when": "!config.emacs-mcx.useMetaPrefixMacCmd"
+        "command": "workbench.action.showCommands"
       },
       {
         "mac": "cmd+x",
@@ -4874,8 +4872,7 @@
       },
       {
         "key": "ctrl+alt+space",
-        "command": "workbench.action.toggleSidebarVisibility",
-        "when": "!config.emacs-mcx.useMetaPrefixMacCmd"
+        "command": "workbench.action.toggleSidebarVisibility"
       },
       {
         "mac": "ctrl+cmd+space",
@@ -4975,7 +4972,7 @@
       {
         "key": "ctrl+alt+f",
         "command": "emacs-mcx.paredit.forwardSexp",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "ctrl+cmd+f",
@@ -4995,7 +4992,7 @@
       {
         "key": "ctrl+alt+b",
         "command": "emacs-mcx.paredit.backwardSexp",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "ctrl+cmd+b",
@@ -5015,7 +5012,7 @@
       {
         "key": "ctrl+alt+shift+2",
         "command": "emacs-mcx.paredit.markSexp",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "ctrl+cmd+shift+2",
@@ -5040,7 +5037,7 @@
       {
         "key": "ctrl+alt+k",
         "command": "emacs-mcx.paredit.killSexp",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "ctrl+cmd+k",
@@ -5060,7 +5057,7 @@
       {
         "key": "ctrl+alt+backspace",
         "command": "emacs-mcx.paredit.backwardKillSexp",
-        "when": "editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorTextFocus"
       },
       {
         "mac": "ctrl+cmd+backspace",
@@ -5220,7 +5217,7 @@
       {
         "key": "alt+.",
         "command": "emacs-mcx.findDefinitions",
-        "when": "editorHasDefinitionProvider && editorTextFocus && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "editorHasDefinitionProvider && editorTextFocus"
       },
       {
         "mac": "cmd+.",
@@ -5240,7 +5237,7 @@
       {
         "key": "alt+,",
         "command": "workbench.action.navigateBack",
-        "when": "canNavigateBack && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "canNavigateBack"
       },
       {
         "mac": "cmd+,",
@@ -5260,7 +5257,7 @@
       {
         "key": "ctrl+alt+,",
         "command": "workbench.action.navigateForward",
-        "when": "canNavigateForward && !config.emacs-mcx.useMetaPrefixMacCmd"
+        "when": "canNavigateForward"
       },
       {
         "mac": "ctrl+cmd+,",


### PR DESCRIPTION
Reverts whitphx/vscode-emacs-mcx#2329

https://github.com/whitphx/vscode-emacs-mcx/pull/2320 fixed  #2319, so just reverting #2329 is not a good solution.