### PR TITLE
Revert "Set editor.find.seedSearchStringFromSelection: never as defau…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ See https://github.com/whitphx/vscode-emacs-mcx/issues/137 for the details about
 
 ### i-search (`C-s`) is initialized with the currently selected string and the previous search is removed.
 
-This is VSCode's design that an extension cannot control.
-To disable it, you should set `editor.find.seedSearchStringFromSelection` VSCode setting as `"never"`.
+Setting `editor.find.seedSearchStringFromSelection` as `"never"` can change this behavior.
 It makes the find widget work similarly to Emacs.
 
 Refs:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ See https://github.com/whitphx/vscode-emacs-mcx/issues/137 for the details about
 
 ### i-search (`C-s`) is initialized with the currently selected string and the previous search is removed.
 
-Set `editor.find.seedSearchStringFromSelection` VSCode setting as `"never"`.
+This is VSCode's design that an extension cannot control.
+To disable it, you should set `editor.find.seedSearchStringFromSelection` VSCode setting as `"never"`.
+It makes the find widget work similarly to Emacs.
 
 Refs:
 

--- a/package.json
+++ b/package.json
@@ -199,9 +199,6 @@
         }
       }
     },
-    "configurationDefaults": {
-      "editor.find.seedSearchStringFromSelection": "never"
-    },
     "commands": [
       {
         "command": "emacs-mcx.addSelectionToNextFindMatch",


### PR DESCRIPTION
…lt by using configurationDefaults contribution that has been available since 1.63 (#2349)"

This reverts commit c650a17760586d35bb5774e038ae558f2a7f66e9.

#2355

It was violating this policy, #1767.