### PR TITLE
Remove textInputFocus from the when condition of ctrl+y assigned to c…

### DIFF
--- a/keybindings/move-edit.json
+++ b/keybindings/move-edit.json
@@ -228,13 +228,19 @@
   },
   {
     "key": "ctrl+w",
-    "command": "editor.action.clipboardCutAction", // Ref: https://github.com/microsoft/vscode/issues/251427#issuecomment-3106145657
-    "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus || textInputFocus) && !isComposing" // I picked up the conditions from https://www.whitphx.info/posts/20230217-vscode-undocumented-contexts/ manually without enough testing... Propose a fix on this line if you find a better condition or any issue.
+    // Ref: https://github.com/microsoft/vscode/issues/251427#issuecomment-3106145657
+    "command": "editor.action.clipboardCutAction",
+    // I picked up the conditions from https://www.whitphx.info/posts/20230217-vscode-undocumented-contexts/ manually without enough testing... Propose a fix on this line if you find a better condition or any issue.
+    // CAUTION: `textInputFocus` MUST NOT be included here because it becomes true even when the text editor is focused.
+    "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus) && !isComposing"
   },
   {
     "key": "ctrl+y",
-    "command": "editor.action.clipboardPasteAction", // Ref: https://github.com/microsoft/vscode/issues/251427#issuecomment-3106145657
-    "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus || textInputFocus) && !isComposing" // I picked up the conditions from https://www.whitphx.info/posts/20230217-vscode-undocumented-contexts/ manually without enough testing... Propose a fix on this line if you find a better condition or any issue.
+    // Ref: https://github.com/microsoft/vscode/issues/251427#issuecomment-3106145657
+    "command": "editor.action.clipboardPasteAction",
+    // I picked up the conditions from https://www.whitphx.info/posts/20230217-vscode-undocumented-contexts/ manually without enough testing... Propose a fix on this line if you find a better condition or any issue.
+    // CAUTION: `textInputFocus` MUST NOT be included here because it becomes true even when the text editor is focused.
+    "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus) && !isComposing"
   },
   {
     "key": "meta+y",

--- a/package.json
+++ b/package.json
@@ -2239,12 +2239,12 @@
       {
         "key": "ctrl+w",
         "command": "editor.action.clipboardCutAction",
-        "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus || textInputFocus) && !isComposing"
+        "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus) && !isComposing"
       },
       {
         "key": "ctrl+y",
         "command": "editor.action.clipboardPasteAction",
-        "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus || textInputFocus) && !isComposing"
+        "when": "(findInputFocussed || replaceInputFocussed || inputBoxFocus || patternExcludesInputBoxFocus || patternIncludesInputBoxFocus || searchInputBoxFocus || replaceInputBoxFocus) && !isComposing"
       },
       {
         "key": "alt+y",


### PR DESCRIPTION
…lipboardPasteAction to make ctrl+y work as yank in the text editor

Fixes #2370