### PR TITLE
Call browse-kill-ring from yank-pop when it's called after a non-kill command

### DIFF
--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -208,6 +208,7 @@ export class Yank extends KillYankCommand {
     await this.killYanker.yank(prefixArgument);
     this.emacsController.exitMarkMode();
     revealPrimaryActive(textEditor);
+    MessageManager.showMessage("Mark set"); // `yank` and `exitMarkMode` may close the message, so we call showMessage here.
   }
 }
 
@@ -215,8 +216,16 @@ export class YankPop extends KillYankCommand {
   public readonly id = "yankPop";
 
   public async run(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined): Promise<void> {
-    await this.killYanker.yankPop(prefixArgument);
-    this.emacsController.exitMarkMode();
+    if (this.killYanker.isYankInterrupted()) {
+      // When `M-y` is called after a non-kill command, it works as `yank-from-kill-ring`.
+      // Ref: https://www.gnu.org/software/emacs/news/NEWS.28.html#org41bb559
+      this.emacsController.pushMark(textEditor.selections.map((selection) => selection.active));
+      await this.killYanker.browseKillRing();
+      MessageManager.showMessage("Mark set");
+    } else {
+      await this.killYanker.yankPop(prefixArgument);
+      this.emacsController.exitMarkMode();
+    }
     revealPrimaryActive(textEditor);
   }
 }

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -221,6 +221,7 @@ export class YankPop extends KillYankCommand {
       // Ref: https://www.gnu.org/software/emacs/news/NEWS.28.html#org41bb559
       this.emacsController.pushMark(textEditor.selections.map((selection) => selection.active));
       await this.killYanker.browseKillRing();
+      this.emacsController.exitMarkMode();
       MessageManager.showMessage("Mark set");
     } else {
       await this.killYanker.yankPop(prefixArgument);

--- a/src/commands/kill.ts
+++ b/src/commands/kill.ts
@@ -220,7 +220,7 @@ export class YankPop extends KillYankCommand {
       // When `M-y` is called after a non-kill command, it works as `yank-from-kill-ring`.
       // Ref: https://www.gnu.org/software/emacs/news/NEWS.28.html#org41bb559
       this.emacsController.pushMark(textEditor.selections.map((selection) => selection.active));
-      await this.killYanker.browseKillRing();
+      await this.killYanker.yankFromKillRing();
       this.emacsController.exitMarkMode();
       MessageManager.showMessage("Mark set");
     } else {
@@ -235,7 +235,9 @@ export class BrowseKillRing extends KillYankCommand {
   public readonly id = "browseKillRing";
 
   public async run(textEditor: TextEditor, isInMarkMode: boolean, prefixArgument: number | undefined) {
-    await this.killYanker.browseKillRing();
+    // In Emacs, `browse-kill-ring` is different from `yank-from-kill-ring`,
+    // but we use `yank-from-kill-ring` here for simplicity in this extension.
+    await this.killYanker.yankFromKillRing();
     revealPrimaryActive(textEditor);
   }
 }

--- a/src/kill-yank/browse.ts
+++ b/src/kill-yank/browse.ts
@@ -19,6 +19,7 @@ export async function quickPickKillRing(
   try {
     return await new Promise<KillRingEntity | undefined>((resolve) => {
       const input = vscode.window.createQuickPick<KillRingEntityQuickPickItem>();
+      input.placeholder = "Kill Ring";
 
       input.items = killRing.map((entity) => new KillRingEntityQuickPickItem(entity));
 

--- a/src/kill-yank/index.ts
+++ b/src/kill-yank/index.ts
@@ -286,7 +286,7 @@ export class KillYanker implements vscode.Disposable {
     await this.yankKillRingEntity(killRingEntity);
   }
 
-  public async browseKillRing(): Promise<void> {
+  public async yankFromKillRing(): Promise<void> {
     const killRing = this.killRing;
     if (killRing == null) {
       return;

--- a/src/kill-yank/index.ts
+++ b/src/kill-yank/index.ts
@@ -222,13 +222,26 @@ export class KillYanker implements vscode.Disposable {
     await vscode.commands.executeCommand("paste", { text: flattenedText });
   }
 
-  public async revertPreviousYank() {
+  private async revertPreviousYank() {
     if (this.isYankInterrupted()) {
       return;
     }
 
     for (let i = 0; i < this.prevYankChanges; ++i) {
       await vscode.commands.executeCommand("undo");
+    }
+  }
+
+  private async pushClipboardTextIfNeeded(): Promise<void> {
+    if (this.killRing == null) {
+      return;
+    }
+
+    const latestKill = this.killRing.getLatest();
+    const clipboardText = await vscode.env.clipboard.readText();
+    if (latestKill == null || !latestKill.isSameClipboardText(clipboardText)) {
+      const newClipboardTextKillRingEntity = new ClipboardTextKillRingEntity(clipboardText);
+      this.killRing.push(newClipboardTextKillRingEntity);
     }
   }
 
@@ -248,12 +261,7 @@ export class KillYanker implements vscode.Disposable {
     }
 
     if (delta === 1) {
-      const latestKill = this.killRing.getLatest();
-      const clipboardText = await vscode.env.clipboard.readText();
-      if (latestKill == null || !latestKill.isSameClipboardText(clipboardText)) {
-        const newClipboardTextKillRingEntity = new ClipboardTextKillRingEntity(clipboardText);
-        this.killRing.push(newClipboardTextKillRingEntity);
-      }
+      await this.pushClipboardTextIfNeeded();
     }
 
     const killRingEntityToPaste = this.killRing.pop(delta - 1);
@@ -291,6 +299,8 @@ export class KillYanker implements vscode.Disposable {
     if (killRing == null) {
       return;
     }
+
+    await this.pushClipboardTextIfNeeded();
 
     const selectedEntity = await killRing.browse();
     if (selectedEntity) {

--- a/src/kill-yank/index.ts
+++ b/src/kill-yank/index.ts
@@ -1,6 +1,7 @@
 import { Minibuffer } from "src/minibuffer";
 import * as vscode from "vscode";
 import { Position, Range, TextEditor } from "vscode";
+import { MessageManager } from "../message";
 import { equalPositions } from "../utils";
 import type { IEmacsController } from "../emulator";
 import { KillRing } from "./kill-ring";
@@ -269,9 +270,7 @@ export class KillYanker implements vscode.Disposable {
     }
 
     if (this.isYankInterrupted()) {
-      // When `M-y` is called after a non-kill command, it works as `yank-from-kill-ring`.
-      // Ref: https://www.gnu.org/software/emacs/news/NEWS.28.html#org41bb559
-      await this.yankFromKillRing();
+      MessageManager.showMessage("Previous command was not a yank");
       return;
     }
 
@@ -285,12 +284,6 @@ export class KillYanker implements vscode.Disposable {
     }
 
     await this.yankKillRingEntity(killRingEntity);
-  }
-
-  public yankFromKillRing(): Promise<void> {
-    // In Emacs, `yank-from-kill-ring` and `browse-kill-ring` are different commands,
-    // but we can treat them the same in this extension.
-    return this.browseKillRing();
   }
 
   public async browseKillRing(): Promise<void> {
@@ -343,7 +336,7 @@ export class KillYanker implements vscode.Disposable {
     return success;
   }
 
-  private isYankInterrupted(): boolean {
+  public isYankInterrupted(): boolean {
     if (this.continuousYankInterrupted) {
       return true;
     }


### PR DESCRIPTION
Requested behavior of `M-y` in #2083