### PR TITLE
Dev/refactoring args structure

### DIFF
--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -154,7 +154,7 @@ export class IsearchExit extends IsearchCommand {
     textEditor: TextEditor,
     isInMarkMode: boolean,
     prefixArgument: number | undefined,
-    args?: unknown[],
+    args?: unknown,
   ): Thenable<void> {
     return vscode.commands.executeCommand("closeFindWidget").then(() => {
       const startSelections = this.searchState.startSelections;
@@ -174,8 +174,7 @@ export class IsearchExit extends IsearchCommand {
         }
       }
 
-      const arg0 = args?.[0];
-      const maybeNextCommand = (arg0 as { then?: string } | undefined)?.then;
+      const maybeNextCommand = (args as { then?: string } | undefined)?.then;
       const nextCommand = typeof maybeNextCommand === "string" ? maybeNextCommand : undefined;
       if (nextCommand) {
         return vscode.commands.executeCommand(nextCommand);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -43,7 +43,7 @@ export abstract class EmacsCommand {
     textEditor: TextEditor,
     isInMarkMode: boolean,
     prefixArgument: number | undefined,
-    args?: unknown[],
+    args?: unknown,
   ): void | Thenable<unknown>;
 
   public onDidInterruptTextEditor?(event: InterruptEvent): void;

--- a/src/commands/registers.ts
+++ b/src/commands/registers.ts
@@ -171,7 +171,7 @@ export class RegisterNameCommand extends EmacsCommand {
     textEditor: vscode.TextEditor,
     isInMarkMode: boolean,
     prefixArgument: number | undefined,
-    args?: unknown[],
+    args?: unknown,
   ): void | Thenable<void> {
     const commandType = this.registerCommandState.acceptingRegisterName;
     if (!commandType) {
@@ -180,7 +180,7 @@ export class RegisterNameCommand extends EmacsCommand {
 
     this.registerCommandState.stopAcceptingRegisterName();
 
-    const registerName = args?.[0];
+    const registerName = args;
     if (typeof registerName !== "string" || registerName.length !== 1) {
       return;
     }

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -463,7 +463,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
     return vscode.commands.executeCommand("setContext", "emacs-mcx.acceptingArgument", newState);
   };
 
-  public runCommand(commandName: string, args?: unknown[]): Thenable<unknown> | void {
+  public runCommand(commandName: string, args?: unknown): Thenable<unknown> | void {
     const command = this.commandRegistry.get(commandName);
 
     if (command === undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ export function activate(context: vscode.ExtensionContext): void {
   ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const disposable = vscode.commands.registerCommand(commandName, (args: Unreliable<any>) => {
-      logger.debug(`[command]\t Command "${commandName}" executed with args (${JSON.stringify(args)})`);
+      logger.debug(`[command]\t Command "${commandName}" executed with args ${JSON.stringify(args)}`);
 
       const emulator = getAndUpdateEmulator();
       if (!emulator) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,22 +79,22 @@ export function activate(context: vscode.ExtensionContext): void {
 
   function registerEmulatorCommand(
     commandName: string,
-    callback: (emulator: EmacsEmulator, ...args: Unreliable<any>[]) => unknown, // eslint-disable-line @typescript-eslint/no-explicit-any
-    onNoEmulator?: (...args: unknown[]) => unknown,
+    callback: (emulator: EmacsEmulator, args: Unreliable<any>) => unknown, // eslint-disable-line @typescript-eslint/no-explicit-any
+    onNoEmulator?: (args: Unreliable<any>) => unknown, // eslint-disable-line @typescript-eslint/no-explicit-any
   ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const disposable = vscode.commands.registerCommand(commandName, (...args: Unreliable<any>[]) => {
+    const disposable = vscode.commands.registerCommand(commandName, (args: Unreliable<any>) => {
       logger.debug(`[command]\t Command "${commandName}" executed with args (${JSON.stringify(args)})`);
 
       const emulator = getAndUpdateEmulator();
       if (!emulator) {
         if (typeof onNoEmulator === "function") {
-          return onNoEmulator(...args);
+          return onNoEmulator(args);
         }
         return;
       }
 
-      return callback(emulator, ...args);
+      return callback(emulator, args);
     });
     context.subscriptions.push(disposable);
   }
@@ -188,7 +188,7 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("isearchAbort");
   });
 
-  registerEmulatorCommand("emacs-mcx.isearchExit", (emulator, ...args) => {
+  registerEmulatorCommand("emacs-mcx.isearchExit", (emulator, args) => {
     return emulator.runCommand("isearchExit", args);
   });
 
@@ -396,16 +396,16 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("jumpToRegister");
   });
 
-  registerEmulatorCommand("emacs-mcx.registerNameCommand", (emulator, ...args) => {
-    return emulator.runCommand("registerNameCommand", args);
+  registerEmulatorCommand("emacs-mcx.registerNameCommand", (emulator, arg0) => {
+    return emulator.runCommand("registerNameCommand", arg0);
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator, ...args) => {
-    return emulator.runCommand("scrollOtherWindow", args);
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator, arg0) => {
+    return emulator.runCommand("scrollOtherWindow", arg0);
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator, ...args) => {
-    return emulator.runCommand("scrollOtherWindowDown", args);
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator, arg0) => {
+    return emulator.runCommand("scrollOtherWindowDown", arg0);
   });
 
   registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, arg0) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,44 +102,44 @@ export function activate(context: vscode.ExtensionContext): void {
   if (Configuration.instance.enableOverridingTypeCommand) {
     registerEmulatorCommand(
       "type",
-      (emulator, arg0) => {
-        const text = (arg0 as unknown as { text: string }).text; // XXX: The arguments of `type` is guaranteed to have this signature.
+      (emulator, args) => {
+        const text = (args as unknown as { text: string }).text; // XXX: The arguments of `type` is guaranteed to have this signature.
         // Capture typing characters for prefix argument functionality.
         logger.debug(`[type command]\t args.text = "${text}"`);
 
         return emulator.type(text);
       },
-      (arg0) => vscode.commands.executeCommand("default:type", arg0),
+      (args) => vscode.commands.executeCommand("default:type", args),
     );
   }
 
-  registerEmulatorCommand("emacs-mcx.subsequentArgumentDigit", (emulator, arg0) => {
-    if (!Array.isArray(arg0)) {
+  registerEmulatorCommand("emacs-mcx.subsequentArgumentDigit", (emulator, args) => {
+    if (!Array.isArray(args)) {
       return;
     }
-    const arg = arg0[0];
+    const arg = args[0];
     if (typeof arg !== "number") {
       return;
     }
     return emulator.subsequentArgumentDigit(arg);
   });
 
-  registerEmulatorCommand("emacs-mcx.digitArgument", (emulator, arg0) => {
-    if (!Array.isArray(arg0)) {
+  registerEmulatorCommand("emacs-mcx.digitArgument", (emulator, args) => {
+    if (!Array.isArray(args)) {
       return;
     }
-    const arg = arg0[0];
+    const arg = args[0];
     if (typeof arg !== "number") {
       return;
     }
     return emulator.digitArgument(arg);
   });
 
-  registerEmulatorCommand("emacs-mcx.typeChar", (emulator, arg0) => {
-    if (!Array.isArray(arg0)) {
+  registerEmulatorCommand("emacs-mcx.typeChar", (emulator, args) => {
+    if (!Array.isArray(args)) {
       return;
     }
-    const arg = arg0[0];
+    const arg = args[0];
     if (typeof arg !== "string") {
       return;
     }
@@ -396,28 +396,28 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("jumpToRegister");
   });
 
-  registerEmulatorCommand("emacs-mcx.registerNameCommand", (emulator, arg0) => {
-    return emulator.runCommand("registerNameCommand", arg0);
+  registerEmulatorCommand("emacs-mcx.registerNameCommand", (emulator, args) => {
+    return emulator.runCommand("registerNameCommand", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator, arg0) => {
-    return emulator.runCommand("scrollOtherWindow", arg0);
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator, args) => {
+    return emulator.runCommand("scrollOtherWindow", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator, arg0) => {
-    return emulator.runCommand("scrollOtherWindowDown", arg0);
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator, args) => {
+    return emulator.runCommand("scrollOtherWindowDown", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, arg0) => {
-    if (typeof arg0 !== "object" || arg0 == null || Array.isArray(arg0)) {
+  registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, args) => {
+    if (typeof args !== "object" || args == null || Array.isArray(args)) {
       return;
     }
 
     if (
-      typeof arg0?.command === "string" &&
-      (typeof arg0?.prefixArgumentKey === "string" || arg0?.prefixArgumentKey == null)
+      typeof args?.command === "string" &&
+      (typeof args?.prefixArgumentKey === "string" || args?.prefixArgumentKey == null)
     ) {
-      return emulator.executeCommandWithPrefixArgument(arg0["command"], arg0["args"], arg0["prefixArgumentKey"]);
+      return emulator.executeCommandWithPrefixArgument(args["command"], args["args"], args["prefixArgumentKey"]);
     }
   });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -400,12 +400,12 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.runCommand("registerNameCommand", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator, args) => {
-    return emulator.runCommand("scrollOtherWindow", args);
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator) => {
+    return emulator.runCommand("scrollOtherWindow");
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator, args) => {
-    return emulator.runCommand("scrollOtherWindowDown", args);
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator) => {
+    return emulator.runCommand("scrollOtherWindowDown");
   });
 
   registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, args) => {

--- a/src/test/suite/commands/find.test.ts
+++ b/src/test/suite/commands/find.test.ts
@@ -49,7 +49,7 @@ suite("isearch", () => {
 
     setEmptyCursors(activeTextEditor, [2, 0]);
 
-    await emulator.runCommand("isearchExit", [{ then: "cursorTop" }]);
+    await emulator.runCommand("isearchExit", { then: "cursorTop" });
 
     assertCursorsEqual(activeTextEditor, [0, 0]);
   });

--- a/src/test/suite/position-register.test.ts
+++ b/src/test/suite/position-register.test.ts
@@ -28,14 +28,14 @@ suite("Point registers", () => {
     // Save position
     setEmptyCursors(activeTextEditor, [0, 2]);
     await emulator.runCommand("pointToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [0, 2]);
 
     // Move cursor and jump back
     setEmptyCursors(activeTextEditor, [1, 5]);
     await emulator.runCommand("jumpToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [0, 2]);
   });
@@ -44,14 +44,14 @@ suite("Point registers", () => {
     // Save multiple cursor positions
     setEmptyCursors(activeTextEditor, [0, 2], [1, 3]);
     await emulator.runCommand("pointToRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [0, 2], [1, 3]);
 
     // Move cursors and jump back
     setEmptyCursors(activeTextEditor, [2, 5]);
     await emulator.runCommand("jumpToRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [0, 2], [1, 3]);
   });
@@ -63,7 +63,7 @@ suite("Point registers", () => {
     await emulator.runCommand("nextLine");
     await emulator.runCommand("forwardChar");
     await emulator.runCommand("pointToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assert.equal(emulator.isInMarkMode, true);
     assertTextEqual(activeTextEditor, initialText);
     assertSelectionsEqual(activeTextEditor, [0, 2, 1, 3]);
@@ -72,7 +72,7 @@ suite("Point registers", () => {
     emulator.exitMarkMode();
     setEmptyCursors(activeTextEditor, [2, 5]);
     await emulator.runCommand("jumpToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [1, 3]);
   });
@@ -81,7 +81,7 @@ suite("Point registers", () => {
     // Save position
     setEmptyCursors(activeTextEditor, [0, 2]);
     await emulator.runCommand("pointToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [0, 2]);
 
@@ -93,7 +93,7 @@ suite("Point registers", () => {
 
     // Move cursor and jump back
     await emulator.runCommand("jumpToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(vscode.window.activeTextEditor!, initialText);
     assertCursorsEqual(vscode.window.activeTextEditor!, [0, 2]);
   });
@@ -101,7 +101,7 @@ suite("Point registers", () => {
   test("jump to non-existent register", async () => {
     setEmptyCursors(activeTextEditor, [0, 0]);
     await emulator.runCommand("jumpToRegister");
-    await emulator.runCommand("registerNameCommand", ["z"]);
+    await emulator.runCommand("registerNameCommand", "z");
     assertTextEqual(activeTextEditor, initialText);
     assertCursorsEqual(activeTextEditor, [0, 0]);
   });

--- a/src/test/suite/text-register.test.ts
+++ b/src/test/suite/text-register.test.ts
@@ -33,7 +33,7 @@ suite("Text registers", () => {
     await emulator.runCommand("forwardChar");
     assertSelectionsEqual(activeTextEditor, [0, 2, 1, 4]);
     await emulator.runCommand("copyToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "0123456789\nabcdefghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [1, 4]);
     assert.equal(emulator.isInMarkMode, false);
@@ -42,7 +42,7 @@ suite("Text registers", () => {
     setEmptyCursors(activeTextEditor, [0, 2]);
     await emulator.setMarkCommand();
     await emulator.runCommand("copyToRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "0123456789\nabcdefghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [0, 2]);
     assert.equal(emulator.isInMarkMode, false);
@@ -50,17 +50,17 @@ suite("Text registers", () => {
     await clearTextEditor(activeTextEditor);
 
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["c"]);
+    await emulator.runCommand("registerNameCommand", "c");
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "23456789\nabcd");
     assertCursorsEqual(activeTextEditor, [1, 4]);
   });
@@ -74,7 +74,7 @@ suite("Text registers", () => {
     assertSelectionsEqual(activeTextEditor, [0, 2, 1, 4]);
     await emulator.universalArgument(); // C-u
     await emulator.runCommand("copyToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "01efghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [0, 2]);
     assert.equal(emulator.isInMarkMode, false);
@@ -84,7 +84,7 @@ suite("Text registers", () => {
     await emulator.setMarkCommand();
     await emulator.universalArgument(); // C-u
     await emulator.runCommand("copyToRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "01efghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [0, 2]);
     assert.equal(emulator.isInMarkMode, false);
@@ -92,13 +92,13 @@ suite("Text registers", () => {
     // Insert
     setEmptyCursors(activeTextEditor, [0, 2]);
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "0123456789\nabcdefghij\nABCDEFGHIJ");
 
     // Insert empty string
     setEmptyCursors(activeTextEditor, [0, 0]);
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "0123456789\nabcdefghij\nABCDEFGHIJ");
   });
 
@@ -110,7 +110,7 @@ suite("Text registers", () => {
     await emulator.runCommand("forwardChar");
     assertSelectionsEqual(activeTextEditor, [0, 2, 1, 4]);
     await emulator.runCommand("copyRectangleToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "0123456789\nabcdefghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [1, 4]);
     assert.equal(emulator.isInMarkMode, false);
@@ -118,7 +118,7 @@ suite("Text registers", () => {
     // Empty string
     setEmptyCursors(activeTextEditor, [0, 2]);
     await emulator.runCommand("copyRectangleToRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "0123456789\nabcdefghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [0, 2]);
     assert.equal(emulator.isInMarkMode, false);
@@ -126,23 +126,23 @@ suite("Text registers", () => {
     await clearTextEditor(activeTextEditor);
 
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["c"]);
+    await emulator.runCommand("registerNameCommand", "c");
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "");
 
     // Insert rectangle
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "23\ncd");
 
     // Insert rectangle in an indented line
     setEmptyCursors(activeTextEditor, [1, 2]);
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "23\ncd23\n  cd");
   });
 
@@ -155,7 +155,7 @@ suite("Text registers", () => {
     assertSelectionsEqual(activeTextEditor, [0, 2, 1, 4]);
     await emulator.universalArgument(); // C-u
     await emulator.runCommand("copyRectangleToRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "01456789\nabefghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [1, 2]); // Cursor is kept in the same line
     assert.equal(emulator.isInMarkMode, false);
@@ -164,7 +164,7 @@ suite("Text registers", () => {
     setEmptyCursors(activeTextEditor, [0, 2]);
     await emulator.universalArgument(); // C-u
     await emulator.runCommand("copyRectangleToRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "01456789\nabefghij\nABCDEFGHIJ");
     assertCursorsEqual(activeTextEditor, [0, 2]);
     assert.equal(emulator.isInMarkMode, false);
@@ -172,23 +172,23 @@ suite("Text registers", () => {
     await clearTextEditor(activeTextEditor);
 
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["c"]);
+    await emulator.runCommand("registerNameCommand", "c");
     assertTextEqual(activeTextEditor, "");
     assertCursorsEqual(activeTextEditor, [0, 0]);
 
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["b"]);
+    await emulator.runCommand("registerNameCommand", "b");
     assertTextEqual(activeTextEditor, "");
 
     // Insert rectangle
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "23\ncd");
 
     // Insert rectangle in an indented line
     setEmptyCursors(activeTextEditor, [1, 2]);
     await emulator.runCommand("insertRegister");
-    await emulator.runCommand("registerNameCommand", ["a"]);
+    await emulator.runCommand("registerNameCommand", "a");
     assertTextEqual(activeTextEditor, "23\ncd23\n  cd");
   });
 });


### PR DESCRIPTION
Potentially affected commands:
- [x] isearchExit
- [x] registerNameCommand
- [x] type
- [x] subsequentArgumentDigit
- [x] digitArgument
- [x] typeChar
- [x] scrollOtherWindow
- [x] scrollOtherWindowDown
executeCommandWithPrefixArgument