### PR TITLE
Feature/override prefix argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ This extension makes use of [paredit.js](https://github.com/rksm/paredit.js) to 
 | `C-M-,`                          | Go forward to where you previously invoked M-, (xref-go-forward). It's just bound to VSCode's "Go Forward" (`workbench.action.navigateForward`).           |
 | `M-S-/` (`M-?` with US keyboard) | Find references of an identifier (xref-find-references). It's just bound to VSCode's "References: Find All References" (`references-view.findReferences`). |
 
-## Other commands
+## Other commands/APIs
 
 ### `emacs-mcx.executeCommandWithPrefixArgument`
 
@@ -474,6 +474,24 @@ You can change the key name of the prefix argument.
 
 - `C-x e` will call the command `foo` with the argument `{}`.
 - `C-u C-x e` will call the command `foo` with the argument `{ repeat: 4 }`.
+
+### Overriding the prefix argument
+
+When you define a keybinding for `emacs-mcx.*` commands, you can override the prefix argument by specifying the `prefixArgument` in the keybinding's arguments.
+
+For example:
+
+```json
+{
+  "key": "alt+shift+y",
+  "command": "emacs-mcx.yankPop",
+  "args": {
+    "prefixArgument": -1
+  }
+}
+```
+
+With this keybinding, you can call `emacs-mcx.yankPop` command with a prefix argument `-1` by pressing `alt+shift+y`.
 
 ## Conflicts with default key bindings
 

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -469,7 +469,9 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
 
     // `args["prefixArgument"]` overrides the prefix argument.
     const maybePrefixArgumentOverride =
-      args != null && typeof args === "object" && !Array.isArray(args) && "prefixArgument" in args ? args.prefixArgument : undefined;
+      args != null && typeof args === "object" && !Array.isArray(args) && "prefixArgument" in args
+        ? args.prefixArgument
+        : undefined;
     const prefixArgumentOverride =
       typeof maybePrefixArgumentOverride === "number" && !isNaN(maybePrefixArgumentOverride)
         ? maybePrefixArgumentOverride

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -469,7 +469,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
 
     // `args["prefixArgument"]` overrides the prefix argument.
     const maybePrefixArgumentOverride =
-      args != null && typeof args === "object" && "prefixArgument" in args ? args.prefixArgument : undefined;
+      args != null && typeof args === "object" && !Array.isArray(args) && "prefixArgument" in args ? args.prefixArgument : undefined;
     const prefixArgumentOverride =
       typeof maybePrefixArgumentOverride === "number" && !isNaN(maybePrefixArgumentOverride)
         ? maybePrefixArgumentOverride

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -467,7 +467,14 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
       throw Error(`command ${commandName} is not found`);
     }
 
-    const prefixArgument = this.prefixArgumentHandler.getPrefixArgument();
+    const maybePrefixArgumentOverride =
+      args != null && typeof args === "object" && "prefixArgument" in args ? args.prefixArgument : undefined;
+    const prefixArgumentOverride =
+      typeof maybePrefixArgumentOverride === "number" && !isNaN(maybePrefixArgumentOverride)
+        ? maybePrefixArgumentOverride
+        : undefined;
+
+    const prefixArgument = prefixArgumentOverride ?? this.prefixArgumentHandler.getPrefixArgument();
 
     return Promise.all([
       command.isIntermediateCommand ? null : this.prefixArgumentHandler.cancel(),

--- a/src/emulator.ts
+++ b/src/emulator.ts
@@ -467,6 +467,7 @@ export class EmacsEmulator implements IEmacsController, vscode.Disposable {
       throw Error(`command ${commandName} is not found`);
     }
 
+    // `args["prefixArgument"]` overrides the prefix argument.
     const maybePrefixArgumentOverride =
       args != null && typeof args === "object" && "prefixArgument" in args ? args.prefixArgument : undefined;
     const prefixArgumentOverride =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -148,61 +148,61 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   moveCommandIds.map((commandName) => {
-    registerEmulatorCommand(`emacs-mcx.${commandName}`, (emulator) => {
-      return emulator.runCommand(commandName);
+    registerEmulatorCommand(`emacs-mcx.${commandName}`, (emulator, args) => {
+      return emulator.runCommand(commandName, args);
     });
   });
 
-  registerEmulatorCommand("emacs-mcx.gotoLine", (emulator) => {
-    return emulator.runCommand("gotoLine");
+  registerEmulatorCommand("emacs-mcx.gotoLine", (emulator, args) => {
+    return emulator.runCommand("gotoLine", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.findDefinitions", (emulator) => {
-    return emulator.runCommand("findDefinitions");
+  registerEmulatorCommand("emacs-mcx.findDefinitions", (emulator, args) => {
+    return emulator.runCommand("findDefinitions", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.isearchForward", (emulator) => {
-    return emulator.runCommand("isearchForward");
+  registerEmulatorCommand("emacs-mcx.isearchForward", (emulator, args) => {
+    return emulator.runCommand("isearchForward", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.isearchBackward", (emulator) => {
-    return emulator.runCommand("isearchBackward");
+  registerEmulatorCommand("emacs-mcx.isearchBackward", (emulator, args) => {
+    return emulator.runCommand("isearchBackward", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.isearchForwardRegexp", (emulator) => {
-    return emulator.runCommand("isearchForwardRegexp");
+  registerEmulatorCommand("emacs-mcx.isearchForwardRegexp", (emulator, args) => {
+    return emulator.runCommand("isearchForwardRegexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.isearchBackwardRegexp", (emulator) => {
-    return emulator.runCommand("isearchBackwardRegexp");
+  registerEmulatorCommand("emacs-mcx.isearchBackwardRegexp", (emulator, args) => {
+    return emulator.runCommand("isearchBackwardRegexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.queryReplace", (emulator) => {
-    return emulator.runCommand("queryReplace");
+  registerEmulatorCommand("emacs-mcx.queryReplace", (emulator, args) => {
+    return emulator.runCommand("queryReplace", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.queryReplaceRegexp", (emulator) => {
-    return emulator.runCommand("queryReplaceRegexp");
+  registerEmulatorCommand("emacs-mcx.queryReplaceRegexp", (emulator, args) => {
+    return emulator.runCommand("queryReplaceRegexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.isearchAbort", (emulator) => {
-    return emulator.runCommand("isearchAbort");
+  registerEmulatorCommand("emacs-mcx.isearchAbort", (emulator, args) => {
+    return emulator.runCommand("isearchAbort", args);
   });
 
   registerEmulatorCommand("emacs-mcx.isearchExit", (emulator, args) => {
     return emulator.runCommand("isearchExit", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.deleteBackwardChar", (emulator) => {
-    return emulator.runCommand("deleteBackwardChar");
+  registerEmulatorCommand("emacs-mcx.deleteBackwardChar", (emulator, args) => {
+    return emulator.runCommand("deleteBackwardChar", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.deleteForwardChar", (emulator) => {
-    return emulator.runCommand("deleteForwardChar");
+  registerEmulatorCommand("emacs-mcx.deleteForwardChar", (emulator, args) => {
+    return emulator.runCommand("deleteForwardChar", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.deleteHorizontalSpace", (emulator) => {
-    return emulator.runCommand("deleteHorizontalSpace");
+  registerEmulatorCommand("emacs-mcx.deleteHorizontalSpace", (emulator, args) => {
+    return emulator.runCommand("deleteHorizontalSpace", args);
   });
 
   registerEmulatorCommand("emacs-mcx.universalArgument", (emulator) => {
@@ -213,80 +213,80 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.negativeArgument();
   });
 
-  registerEmulatorCommand("emacs-mcx.killLine", (emulator) => {
-    return emulator.runCommand("killLine");
+  registerEmulatorCommand("emacs-mcx.killLine", (emulator, args) => {
+    return emulator.runCommand("killLine", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.killWord", (emulator) => {
-    return emulator.runCommand("killWord");
+  registerEmulatorCommand("emacs-mcx.killWord", (emulator, args) => {
+    return emulator.runCommand("killWord", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.backwardKillWord", (emulator) => {
-    return emulator.runCommand("backwardKillWord");
+  registerEmulatorCommand("emacs-mcx.backwardKillWord", (emulator, args) => {
+    return emulator.runCommand("backwardKillWord", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.killWholeLine", (emulator) => {
-    return emulator.runCommand("killWholeLine");
+  registerEmulatorCommand("emacs-mcx.killWholeLine", (emulator, args) => {
+    return emulator.runCommand("killWholeLine", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.killRegion", (emulator) => {
-    return emulator.runCommand("killRegion");
+  registerEmulatorCommand("emacs-mcx.killRegion", (emulator, args) => {
+    return emulator.runCommand("killRegion", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.copyRegion", (emulator) => {
-    return emulator.runCommand("copyRegion");
+  registerEmulatorCommand("emacs-mcx.copyRegion", (emulator, args) => {
+    return emulator.runCommand("copyRegion", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.yank", (emulator) => {
-    return emulator.runCommand("yank");
+  registerEmulatorCommand("emacs-mcx.yank", (emulator, args) => {
+    return emulator.runCommand("yank", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.yankPop", (emulator) => {
-    return emulator.runCommand("yankPop");
+  registerEmulatorCommand("emacs-mcx.yankPop", (emulator, args) => {
+    return emulator.runCommand("yankPop", args);
   });
-  registerEmulatorCommand("emacs-mcx.yank-pop" /* For backward compatibility */, (emulator) => {
+  registerEmulatorCommand("emacs-mcx.yank-pop" /* For backward compatibility */, (emulator, args) => {
     logger.warn('The command "emacs-mcx.yank-pop" is deprecated. Please use "emacs-mcx.yankPop" instead.');
-    return emulator.runCommand("yankPop");
+    return emulator.runCommand("yankPop", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.browseKillRing", (emulator) => {
-    return emulator.runCommand("browseKillRing");
+  registerEmulatorCommand("emacs-mcx.browseKillRing", (emulator, args) => {
+    return emulator.runCommand("browseKillRing", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.startRectCommand", (emulator) => {
-    return emulator.runCommand("startAcceptingRectCommand");
+  registerEmulatorCommand("emacs-mcx.startRectCommand", (emulator, args) => {
+    return emulator.runCommand("startAcceptingRectCommand", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.killRectangle", (emulator) => {
-    return emulator.runCommand("killRectangle");
+  registerEmulatorCommand("emacs-mcx.killRectangle", (emulator, args) => {
+    return emulator.runCommand("killRectangle", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.copyRectangleAsKill", (emulator) => {
-    return emulator.runCommand("copyRectangleAsKill");
+  registerEmulatorCommand("emacs-mcx.copyRectangleAsKill", (emulator, args) => {
+    return emulator.runCommand("copyRectangleAsKill", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.deleteRectangle", (emulator) => {
-    return emulator.runCommand("deleteRectangle");
+  registerEmulatorCommand("emacs-mcx.deleteRectangle", (emulator, args) => {
+    return emulator.runCommand("deleteRectangle", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.yankRectangle", (emulator) => {
-    return emulator.runCommand("yankRectangle");
+  registerEmulatorCommand("emacs-mcx.yankRectangle", (emulator, args) => {
+    return emulator.runCommand("yankRectangle", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.openRectangle", (emulator) => {
-    return emulator.runCommand("openRectangle");
+  registerEmulatorCommand("emacs-mcx.openRectangle", (emulator, args) => {
+    return emulator.runCommand("openRectangle", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.clearRectangle", (emulator) => {
-    return emulator.runCommand("clearRectangle");
+  registerEmulatorCommand("emacs-mcx.clearRectangle", (emulator, args) => {
+    return emulator.runCommand("clearRectangle", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.stringRectangle", (emulator) => {
-    return emulator.runCommand("stringRectangle");
+  registerEmulatorCommand("emacs-mcx.stringRectangle", (emulator, args) => {
+    return emulator.runCommand("stringRectangle", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.replaceKillRingToRectangle", (emulator) => {
-    return emulator.runCommand("replaceKillRingToRectangle");
+  registerEmulatorCommand("emacs-mcx.replaceKillRingToRectangle", (emulator, args) => {
+    return emulator.runCommand("replaceKillRingToRectangle", args);
   });
 
   registerEmulatorCommand("emacs-mcx.setMarkCommand", (emulator) => {
@@ -305,112 +305,112 @@ export function activate(context: vscode.ExtensionContext): void {
     return emulator.exchangePointAndMark();
   });
 
-  registerEmulatorCommand("emacs-mcx.addSelectionToNextFindMatch", (emulator) => {
-    return emulator.runCommand("addSelectionToNextFindMatch");
+  registerEmulatorCommand("emacs-mcx.addSelectionToNextFindMatch", (emulator, args) => {
+    return emulator.runCommand("addSelectionToNextFindMatch", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.addSelectionToPreviousFindMatch", (emulator) => {
-    return emulator.runCommand("addSelectionToPreviousFindMatch");
+  registerEmulatorCommand("emacs-mcx.addSelectionToPreviousFindMatch", (emulator, args) => {
+    return emulator.runCommand("addSelectionToPreviousFindMatch", args);
   });
 
   registerEmulatorCommand("emacs-mcx.cancel", (emulator) => {
     return emulator.cancel();
   });
 
-  registerEmulatorCommand("emacs-mcx.newLine", (emulator) => {
-    return emulator.runCommand("newLine");
+  registerEmulatorCommand("emacs-mcx.newLine", (emulator, args) => {
+    return emulator.runCommand("newLine", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.transformToUppercase", (emulator) => {
-    return emulator.runCommand("transformToUppercase");
+  registerEmulatorCommand("emacs-mcx.transformToUppercase", (emulator, args) => {
+    return emulator.runCommand("transformToUppercase", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.transformToLowercase", (emulator) => {
-    return emulator.runCommand("transformToLowercase");
+  registerEmulatorCommand("emacs-mcx.transformToLowercase", (emulator, args) => {
+    return emulator.runCommand("transformToLowercase", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.transformToTitlecase", (emulator) => {
-    return emulator.runCommand("transformToTitlecase");
+  registerEmulatorCommand("emacs-mcx.transformToTitlecase", (emulator, args) => {
+    return emulator.runCommand("transformToTitlecase", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.deleteBlankLines", (emulator) => {
-    return emulator.runCommand("deleteBlankLines");
+  registerEmulatorCommand("emacs-mcx.deleteBlankLines", (emulator, args) => {
+    return emulator.runCommand("deleteBlankLines", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.recenterTopBottom", (emulator) => {
-    return emulator.runCommand("recenterTopBottom");
+  registerEmulatorCommand("emacs-mcx.recenterTopBottom", (emulator, args) => {
+    return emulator.runCommand("recenterTopBottom", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.tabToTabStop", (emulator) => {
-    return emulator.runCommand("tabToTabStop");
+  registerEmulatorCommand("emacs-mcx.tabToTabStop", (emulator, args) => {
+    return emulator.runCommand("tabToTabStop", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.deleteIndentation", (emulator) => {
-    return emulator.runCommand("deleteIndentation");
+  registerEmulatorCommand("emacs-mcx.deleteIndentation", (emulator, args) => {
+    return emulator.runCommand("deleteIndentation", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.forwardSexp", (emulator) => {
-    return emulator.runCommand("paredit.forwardSexp");
+  registerEmulatorCommand("emacs-mcx.paredit.forwardSexp", (emulator, args) => {
+    return emulator.runCommand("paredit.forwardSexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.forwardDownSexp", (emulator) => {
-    return emulator.runCommand("paredit.forwardDownSexp");
+  registerEmulatorCommand("emacs-mcx.paredit.forwardDownSexp", (emulator, args) => {
+    return emulator.runCommand("paredit.forwardDownSexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.backwardSexp", (emulator) => {
-    return emulator.runCommand("paredit.backwardSexp");
+  registerEmulatorCommand("emacs-mcx.paredit.backwardSexp", (emulator, args) => {
+    return emulator.runCommand("paredit.backwardSexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.backwardUpSexp", (emulator) => {
-    return emulator.runCommand("paredit.backwardUpSexp");
+  registerEmulatorCommand("emacs-mcx.paredit.backwardUpSexp", (emulator, args) => {
+    return emulator.runCommand("paredit.backwardUpSexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.markSexp", (emulator) => {
-    return emulator.runCommand("paredit.markSexp");
+  registerEmulatorCommand("emacs-mcx.paredit.markSexp", (emulator, args) => {
+    return emulator.runCommand("paredit.markSexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.killSexp", (emulator) => {
-    return emulator.runCommand("paredit.killSexp");
+  registerEmulatorCommand("emacs-mcx.paredit.killSexp", (emulator, args) => {
+    return emulator.runCommand("paredit.killSexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.pareditKill", (emulator) => {
-    return emulator.runCommand("paredit.pareditKill");
+  registerEmulatorCommand("emacs-mcx.paredit.pareditKill", (emulator, args) => {
+    return emulator.runCommand("paredit.pareditKill", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.paredit.backwardKillSexp", (emulator) => {
-    return emulator.runCommand("paredit.backwardKillSexp");
+  registerEmulatorCommand("emacs-mcx.paredit.backwardKillSexp", (emulator, args) => {
+    return emulator.runCommand("paredit.backwardKillSexp", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.copyToRegister", (emulator) => {
-    return emulator.runCommand("copyToRegister");
+  registerEmulatorCommand("emacs-mcx.copyToRegister", (emulator, args) => {
+    return emulator.runCommand("copyToRegister", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.insertRegister", (emulator) => {
-    return emulator.runCommand("insertRegister");
+  registerEmulatorCommand("emacs-mcx.insertRegister", (emulator, args) => {
+    return emulator.runCommand("insertRegister", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.copyRectangleToRegister", (emulator) => {
-    return emulator.runCommand("copyRectangleToRegister");
+  registerEmulatorCommand("emacs-mcx.copyRectangleToRegister", (emulator, args) => {
+    return emulator.runCommand("copyRectangleToRegister", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.pointToRegister", (emulator) => {
-    return emulator.runCommand("pointToRegister");
+  registerEmulatorCommand("emacs-mcx.pointToRegister", (emulator, args) => {
+    return emulator.runCommand("pointToRegister", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.jumpToRegister", (emulator) => {
-    return emulator.runCommand("jumpToRegister");
+  registerEmulatorCommand("emacs-mcx.jumpToRegister", (emulator, args) => {
+    return emulator.runCommand("jumpToRegister", args);
   });
 
   registerEmulatorCommand("emacs-mcx.registerNameCommand", (emulator, args) => {
     return emulator.runCommand("registerNameCommand", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator) => {
-    return emulator.runCommand("scrollOtherWindow");
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindow", (emulator, args) => {
+    return emulator.runCommand("scrollOtherWindow", args);
   });
 
-  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator) => {
-    return emulator.runCommand("scrollOtherWindowDown");
+  registerEmulatorCommand("emacs-mcx.scrollOtherWindowDown", (emulator, args) => {
+    return emulator.runCommand("scrollOtherWindowDown", args);
   });
 
   registerEmulatorCommand("emacs-mcx.executeCommandWithPrefixArgument", (emulator, args) => {


### PR DESCRIPTION
Resolves #2207

The prefix argument passed to a command can be overridden by setting `args["prefixArgument"]`.
```json
{
    "key": "alt+shift+y",
    "command": "emacs-mcx.yankPop",
    "args": {
        "prefixArgument": -1
    }
}
```

NOTE: It's not possible to set it dynamically with this PR's impl, e.g. setting the prefix argument as the negative value of the current prefix argument.
It should be enhanced if actually needed in the future.