### PR TITLE
Remove keybindings starting with `ctrl+x` on Terminal

### DIFF
--- a/keybindings/terminal.json
+++ b/keybindings/terminal.json
@@ -177,16 +177,5 @@
     "key": "meta+y",
     "command": "workbench.action.terminal.copySelection",
     "when": "terminalTextSelectedInFocused || terminalFocus && terminalHasBeenCreated && terminalTextSelected || terminalFocus && terminalProcessSupported && terminalTextSelected || terminalFocus && terminalTextSelected && terminalTextSelectedInFocused || terminalHasBeenCreated && terminalTextSelected && terminalTextSelectedInFocused || terminalProcessSupported && terminalTextSelected && terminalTextSelectedInFocused"
-  },
-  {
-    "keys": ["ctrl+x 2", "ctrl+x 3"], // VSCode terminal only supports horizontal split.
-    "command": "workbench.action.terminal.splitActiveTab",
-    "when": "terminalFocus"
-  },
-  // Splitting
-  {
-    "key": "ctrl+x 0",
-    "command": "workbench.action.terminal.unsplit",
-    "when": "terminalFocus"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -5313,21 +5313,6 @@
         "when": "(terminalTextSelectedInFocused || terminalFocus && terminalHasBeenCreated && terminalTextSelected || terminalFocus && terminalProcessSupported && terminalTextSelected || terminalFocus && terminalTextSelected && terminalTextSelectedInFocused || terminalHasBeenCreated && terminalTextSelected && terminalTextSelectedInFocused || terminalProcessSupported && terminalTextSelected && terminalTextSelectedInFocused) && config.emacs-mcx.useMetaPrefixCtrlLeftBracket"
       },
       {
-        "key": "ctrl+x 2",
-        "command": "workbench.action.terminal.splitActiveTab",
-        "when": "terminalFocus"
-      },
-      {
-        "key": "ctrl+x 3",
-        "command": "workbench.action.terminal.splitActiveTab",
-        "when": "terminalFocus"
-      },
-      {
-        "key": "ctrl+x 0",
-        "command": "workbench.action.terminal.unsplit",
-        "when": "terminalFocus"
-      },
-      {
         "key": "up",
         "command": "showPrevParameterHint",
         "when": "editorFocus && parameterHintsMultipleSignatures && parameterHintsVisible"


### PR DESCRIPTION
because they conflict with a single `ctrl+x` which is expected to send a sequence to the terminal