### PR TITLE
Add Aikido Safe Chain to CI workflows

### DIFF
--- a/.github/actions/install-safe-chain/action.yml
+++ b/.github/actions/install-safe-chain/action.yml
@@ -1,0 +1,29 @@
+# See https://github.com/AikidoSec/safe-chain?tab=readme-ov-file#usage-in-cicd
+name: Install Aikido Safe Chain
+description: Install Aikido Safe Chain in CI mode so subsequent npm/npx invocations are routed through its malware scanner.
+
+inputs:
+  version:
+    description: The safe-chain version to install.
+    required: false
+    default: "1.4.7"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Aikido Safe Chain (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        SAFE_CHAIN_INSTALL_VERSION: ${{ inputs.version }}
+      run: curl -fsSL "https://github.com/AikidoSec/safe-chain/releases/download/${SAFE_CHAIN_INSTALL_VERSION}/install-safe-chain.sh" | sh -s -- --ci
+
+    - name: Install Aikido Safe Chain (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        SAFE_CHAIN_INSTALL_VERSION: ${{ inputs.version }}
+      run: |
+        $url = "https://github.com/AikidoSec/safe-chain/releases/download/$env:SAFE_CHAIN_INSTALL_VERSION/install-safe-chain.ps1"
+        Invoke-WebRequest -Uri $url -OutFile install-safe-chain.ps1 -UseBasicParsing
+        ./install-safe-chain.ps1 -ci

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -27,6 +27,9 @@ jobs:
           node-version-file: .nvmrc
           cache: "npm"
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,7 +28,7 @@ jobs:
           cache: "npm"
 
       - name: Install Aikido Safe Chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
+        uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -83,6 +83,14 @@ jobs:
           node-version-file: .nvmrc
           cache: "npm"
 
+      - name: Install Aikido Safe Chain
+        if: runner.os != 'Windows'
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
+      - name: Install Aikido Safe Chain (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: iex "& { $(iwr 'https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.ps1' -UseBasicParsing) } -ci"
+
       - name: Install dependencies
         run: npm ci
 
@@ -131,6 +139,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: "npm"
+
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -84,12 +84,7 @@ jobs:
           cache: "npm"
 
       - name: Install Aikido Safe Chain
-        if: runner.os != 'Windows'
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
-      - name: Install Aikido Safe Chain (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: iex "& { $(iwr 'https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.ps1' -UseBasicParsing) } -ci"
+        uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: npm ci
@@ -141,7 +136,7 @@ jobs:
           cache: "npm"
 
       - name: Install Aikido Safe Chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
+        uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/update-keybindings.yml
+++ b/.github/workflows/update-keybindings.yml
@@ -23,6 +23,9 @@ jobs:
           node-version: "18"
           cache: "npm"
 
+      - name: Install Aikido Safe Chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/update-keybindings.yml
+++ b/.github/workflows/update-keybindings.yml
@@ -24,7 +24,7 @@ jobs:
           cache: "npm"
 
       - name: Install Aikido Safe Chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
+        uses: ./.github/actions/install-safe-chain
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Install Aikido Safe Chain before every `npm ci` step in the CI workflows so npm/npx invocations are routed through its malware scanner. Pinned to 1.4.7, with the PowerShell installer used for the Windows matrix entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an "Install Aikido Safe Chain" step to CI workflows and introduced a reusable action to run the installer across jobs.
  * The action supports an optional version input and handles installation on both Windows and non-Windows runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->