### PR TITLE
Add Takumi Guard for npm to CI workflows

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write # For Takumi Guard OIDC-based audit logging.
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,6 +30,10 @@ jobs:
           node-version-file: .nvmrc
           cache: "npm"
 
+      - name: Set up Takumi Guard for npm
+        uses: flatt-security/setup-takumi-guard-npm@f0e333d43cd7a88d2caabee1f16048baab3a35a9 # v1.1.1
+        with:
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
       - name: Install Aikido Safe Chain
         uses: ./.github/actions/install-safe-chain
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -72,6 +72,9 @@ jobs:
           - os: ubuntu-latest
             type: "web"
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write # For Takumi Guard OIDC-based audit logging.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -83,6 +86,10 @@ jobs:
           node-version-file: .nvmrc
           cache: "npm"
 
+      - name: Set up Takumi Guard for npm
+        uses: flatt-security/setup-takumi-guard-npm@f0e333d43cd7a88d2caabee1f16048baab3a35a9 # v1.1.1
+        with:
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
       - name: Install Aikido Safe Chain
         uses: ./.github/actions/install-safe-chain
 
@@ -135,6 +142,10 @@ jobs:
           node-version-file: .nvmrc
           cache: "npm"
 
+      - name: Set up Takumi Guard for npm
+        uses: flatt-security/setup-takumi-guard-npm@f0e333d43cd7a88d2caabee1f16048baab3a35a9 # v1.1.1
+        with:
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
       - name: Install Aikido Safe Chain
         uses: ./.github/actions/install-safe-chain
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Check keybinding diff
         run: |
           npm run gen-keys
-          git diff --exit-code || (echo "You have to run 'npm run gen-keys' and commit the updated package.json" && exit -1)
+          git diff --exit-code -- package.json || (echo "You have to run 'npm run gen-keys' and commit the updated package.json" && exit -1)
 
       - name: Build for test
         run: npm run webpack

--- a/.github/workflows/update-keybindings.yml
+++ b/.github/workflows/update-keybindings.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # For Takumi Guard OIDC-based audit logging.
 
     steps:
       - name: Checkout repository
@@ -23,6 +24,10 @@ jobs:
           node-version: "18"
           cache: "npm"
 
+      - name: Set up Takumi Guard for npm
+        uses: flatt-security/setup-takumi-guard-npm@f0e333d43cd7a88d2caabee1f16048baab3a35a9 # v1.1.1
+        with:
+          bot-id: ${{ vars.TAKUMI_GUARD_BOT_ID }}
       - name: Install Aikido Safe Chain
         uses: ./.github/actions/install-safe-chain
 

--- a/cspell.json
+++ b/cspell.json
@@ -72,6 +72,8 @@
     "fuga",
     "piyo",
     "abcdefghij",
-    "klmnopqrst"
+    "klmnopqrst",
+    // Services
+    "takumi"
   ]
 }


### PR DESCRIPTION
Route npm installs through Takumi Guard's registry proxy alongside the existing Aikido Safe Chain interception. The proxy blocks known-malicious packages and, when `vars.TAKUMI_GUARD_BOT_ID` is set, attributes audit logs via OIDC so packages flagged after install surface as breach notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened CI by enabling OIDC/id-token usage and expanding job permissions for release, test, and build pipelines.
  * Integrated Takumi Guard setup into release, test, and build workflows to improve supply-chain checks before dependencies install.
  * Tightened keybinding verification to focus on package manifest changes.
  * Updated spellcheck dictionary to recognize "takumi".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->