### PR TITLE
Dev/disable typescript ata

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -12,8 +12,14 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
-    // Download VS Code, unzip it and run the integration test
-    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+    // Download VS Code, unzip it and run the integration test.
+    // Disable the built-in TypeScript extension to prevent Automatic Type
+    // Acquisition from shelling out to npm, which Aikido Safe-chain blocks in CI.
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: ["--disable-extension=vscode.typescript-language-features"],
+    });
   } catch (err) {
     console.error(err);
     console.error("Failed to run tests");

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 
 import { runTests } from "@vscode/test-electron";
@@ -12,15 +14,25 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
-    // Download VS Code, unzip it and run the integration test.
-    // Disable the built-in TypeScript extension to prevent Automatic Type
-    // Acquisition from shelling out to npm: in CI, Aikido Safe-chain wraps
-    // npm and rejects downloads of packages younger than its minimum-age
-    // threshold (e.g. fresh `types-registry` releases), which fails the step.
+    // Use a throwaway user-data-dir that disables TypeScript Automatic Type
+    // Acquisition. ATA shells out to npm to fetch `types-registry` and
+    // `@types/*`; in CI, Aikido Safe-chain wraps npm and rejects downloads of
+    // packages younger than its minimum-age threshold, failing the test step
+    // after the tests themselves pass. We keep the TypeScript extension
+    // enabled because some tests (e.g. FindDefinitions) rely on its language
+    // features.
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "emacs-mcx-test-user-"));
+    const userSettingsDir = path.join(userDataDir, "User");
+    fs.mkdirSync(userSettingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(userSettingsDir, "settings.json"),
+      JSON.stringify({ "typescript.disableAutomaticTypeAcquisition": true }),
+    );
+
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      launchArgs: ["--disable-extension=vscode.typescript-language-features"],
+      launchArgs: [`--user-data-dir=${userDataDir}`],
     });
   } catch (err) {
     console.error(err);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -29,6 +29,7 @@ async function main() {
       JSON.stringify({ "typescript.disableAutomaticTypeAcquisition": true }),
     );
 
+    // Download VS Code, unzip it and run the integration test
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -14,7 +14,9 @@ async function main() {
 
     // Download VS Code, unzip it and run the integration test.
     // Disable the built-in TypeScript extension to prevent Automatic Type
-    // Acquisition from shelling out to npm, which Aikido Safe-chain blocks in CI.
+    // Acquisition from shelling out to npm: in CI, Aikido Safe-chain wraps
+    // npm and rejects downloads of packages younger than its minimum-age
+    // threshold (e.g. fresh `types-registry` releases), which fails the step.
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,


### PR DESCRIPTION
For example [this CI workflow](https://github.com/whitphx/vscode-emacs-mcx/actions/runs/24619363165/job/71987338570?pr=2816) failed because Aikido blocked downloading an NPM package that violated Aikido's minimum age restriction and the download was initiated by TypeScript's Automatic Type Acquisition.
We should disable the feature in CI because it doesn't help our test but can introduce such issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test runner to use isolated VS Code configuration for improved test consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->