### PR TITLE
Make kill-yank tests resilient to active-editor drift

### DIFF
--- a/src/test/suite/commands/kill-yank/kill-line.test.ts
+++ b/src/test/suite/commands/kill-yank/kill-line.test.ts
@@ -10,6 +10,7 @@ import {
   assertCursorsEqual,
   cleanUpWorkspace,
   clearTextEditor,
+  selectAllText,
   setEmptyCursors,
   setupWorkspace,
   createEmulator,
@@ -150,18 +151,22 @@ abcdefghij
       );
     });
 
-    // Test kill appending is not enabled after cursorMove or some other commands
-    const otherInterruptingCommands = ["editor.action.selectAll"];
+    // Test kill appending is not enabled after cursorMove or some other commands.
+    // Interrupters are passed the target editor so that the test does not rely
+    // on `vscode.window.activeTextEditor`, which can drift during the test run.
+    const otherInterrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [
+      ["selectAllText", (editor) => selectAllText(editor)],
+    ];
 
-    const interruptingCommands: string[] = [...otherInterruptingCommands];
-    interruptingCommands.forEach((interruptingCommand) => {
-      test(`it does not appends killed text if another command (${interruptingCommand}) invoked`, async () => {
+    const interrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [...otherInterrupters];
+    interrupters.forEach(([interrupterLabel, interrupt]) => {
+      test(`it does not appends killed text if another command (${interrupterLabel}) invoked`, async () => {
         setEmptyCursors(activeTextEditor, [1, 5]);
 
         await emulator.runCommand("killLine"); // 2st line
         await emulator.runCommand("killLine"); // EOL of 2st
 
-        await vscode.commands.executeCommand(interruptingCommand); // Interrupt
+        interrupt(activeTextEditor); // Interrupt
 
         const endOfDoc = activeTextEditor.document.lineAt(activeTextEditor.document.lineCount - 1).range.end;
         const secondKillAtEndOfDoc = activeTextEditor.selections.every((selection) =>

--- a/src/test/suite/commands/kill-yank/kill-ring-yank.test.ts
+++ b/src/test/suite/commands/kill-yank/kill-ring-yank.test.ts
@@ -12,6 +12,7 @@ import {
   cleanUpWorkspace,
   clearTextEditor,
   delay,
+  selectAllText,
   setEmptyCursors,
   setupWorkspace,
   createEmulator,
@@ -36,15 +37,15 @@ suite("kill, yank, yank-pop", () => {
 
       // kill 3 times with different texts
       await clearTextEditor(activeTextEditor, "Lorem ipsum");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       await clearTextEditor(activeTextEditor, "dolor sit amet,\nconsectetur adipiscing elit,");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       await clearTextEditor(activeTextEditor, "sed do eiusmod tempor\nincididunt ut labore et\ndolore magna aliqua.");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Initialize with non-empty text
@@ -138,7 +139,7 @@ ABCDEFGHIJ`,
 
       // Kill first
       await clearTextEditor(activeTextEditor, "Lorem ipsum");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Then, copy to clipboard
@@ -206,23 +207,27 @@ ABCDEFGHIJ`,
       );
     });
 
-    // Test yankPop is not executed after cursorMove or some other commands
-    const otherInterruptingCommands = ["editor.action.selectAll"];
-    const interruptingCommands: string[] = [...otherInterruptingCommands];
+    // Test yankPop is not executed after cursorMove or some other commands.
+    // Interrupters are passed the target editor so that the test does not rely
+    // on `vscode.window.activeTextEditor`, which can drift during the test run.
+    const otherInterrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [
+      ["selectAllText", (editor) => selectAllText(editor)],
+    ];
+    const interrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [...otherInterrupters];
 
-    interruptingCommands.forEach((interruptingCommand) => {
-      test(`yankPop works as browse-kill-ring if ${interruptingCommand} is executed after previous yank`, async () => {
+    interrupters.forEach(([interrupterLabel, interrupt]) => {
+      test(`yankPop works as browse-kill-ring if ${interrupterLabel} is executed after previous yank`, async () => {
         const killRing = new KillRing(3);
         const browseStub = sinon.stub(killRing, "browse").resolves(new ClipboardTextKillRingEntity("foo"));
         const emulator = createEmulator(activeTextEditor, killRing);
 
         // Kill texts
         await clearTextEditor(activeTextEditor, "FOO");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         await clearTextEditor(activeTextEditor, "BAR");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         // Initialize with non-empty text
@@ -243,8 +248,8 @@ abcdeBARfghij
 ABCDEFGHIJ`,
         );
 
-        // Interruption command invoked
-        await vscode.commands.executeCommand(interruptingCommand);
+        // Interruption invoked
+        interrupt(activeTextEditor);
 
         // yankPop works as browse-kill-ring
         await emulator.runCommand("yankPop");
@@ -257,18 +262,18 @@ ABCDEFGHIJ`,
         //         );
       });
 
-      test(`yankPop works as browse-kill-ring if ${interruptingCommand} is executed after previous yankPop`, async () => {
+      test(`yankPop works as browse-kill-ring if ${interrupterLabel} is executed after previous yankPop`, async () => {
         const killRing = new KillRing(3);
         const browseStub = sinon.stub(killRing, "browse").resolves(new ClipboardTextKillRingEntity("foo"));
         const emulator = createEmulator(activeTextEditor, killRing);
 
         // Kill texts
         await clearTextEditor(activeTextEditor, "FOO");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         await clearTextEditor(activeTextEditor, "BAR");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         // Initialize with non-empty text
@@ -298,8 +303,8 @@ abcdeFOOfghij
 ABCDEFGHIJ`,
         );
 
-        // Interruption command invoked
-        await vscode.commands.executeCommand(interruptingCommand);
+        // Interruption invoked
+        interrupt(activeTextEditor);
 
         // yankPop works as browse-kill-ring
         await emulator.runCommand("yankPop");
@@ -350,11 +355,11 @@ ABCDEFGHIJ`,
         test(`yankPop works as browse-kill-ring if ${label} is executed after previous yank`, async () => {
           // Kill texts
           await clearTextEditor(activeTextEditor, "FOO");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           await clearTextEditor(activeTextEditor, "BAR");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           // Initialize with non-empty text
@@ -394,11 +399,11 @@ ABCDEFGHIJ`,
         test(`yankPop works as browse-kill-ring if ${label} is executed after previous yankPop`, async () => {
           // Kill texts
           await clearTextEditor(activeTextEditor, "FOO");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           await clearTextEditor(activeTextEditor, "BAR");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           // Initialize with non-empty text
@@ -461,11 +466,11 @@ ABCDEFGHIJ`,
       const emulator = createEmulator(activeTextEditor, killRing);
 
       // Kill text
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Kill empty text
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Now the text is empty
@@ -564,11 +569,11 @@ suite("yank pop with auto-indent", () => {
 
     // Kill texts
     await clearTextEditor(activeTextEditor, "foo"); // No indent
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor);
     await emulator.runCommand("killRegion");
 
     await clearTextEditor(activeTextEditor, "bar"); // No indent
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor);
     await emulator.runCommand("killRegion");
 
     // Initialize with parentheses, that triggers auto-indent to inner text
@@ -785,11 +790,11 @@ suite("With not only single text editor", () => {
 
     // Kill texts from one text editor
     await clearTextEditor(activeTextEditor0, "FOO");
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor0);
     await emulator0.runCommand("killRegion");
 
     await clearTextEditor(activeTextEditor0, "BAR");
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor0);
     await emulator0.runCommand("killRegion");
 
     const activeTextEditor1 = await setupWorkspace("");

--- a/src/test/suite/commands/new-line.test.ts
+++ b/src/test/suite/commands/new-line.test.ts
@@ -250,6 +250,15 @@ eols.forEach(([eol, eolStr]) => {
           // XXX: First, trigger the language's auto-indent feature without any assertion before the main test execution.
           // This is necessary for the test to be successful at VSCode 1.50.
           // It may be because the first execution warms up the language server.
+          // The warm-up runs the same `universalArgument + newLine` path the
+          // main assertion uses (not a single `default:type` `\n`), because
+          // `NewLine.run` with `prefixArgument > 1` fires `default:type`
+          // twice with only a ~33ms gap and then reads the auto-indent
+          // result. On a cold JS language service the second auto-indent
+          // doesn't land in time, the captured pattern is wrong, and the
+          // rebuilt insert ends up missing a ` * ` continuation line.
+          // Priming via the same path reliably warms the second-call
+          // timing as well as the first.
           // TODO: Remove this workaround with later versions of VSCode
           activeTextEditor = await setupWorkspace(initialText, {
             eol,
@@ -259,7 +268,8 @@ eols.forEach(([eol, eolStr]) => {
 
           setEmptyCursors(activeTextEditor, [0, 3]);
 
-          await vscode.commands.executeCommand("default:type", { text: "\n" });
+          await emulator.universalArgument();
+          await emulator.runCommand("newLine");
           await clearTextEditor(activeTextEditor);
           // XXX: (end of the workaround)
 

--- a/src/test/suite/utils.ts
+++ b/src/test/suite/utils.ts
@@ -26,15 +26,17 @@ export async function setupWorkspace(
     language,
   });
 
-  await vscode.window.showTextDocument(doc, column, false);
-
-  const activeTextEditor = vscode.window.activeTextEditor;
-  assert.ok(activeTextEditor);
+  // Return the `TextEditor` that `showTextDocument` resolves to instead of
+  // reading `vscode.window.activeTextEditor` after the call. The active editor
+  // can change between the resolution of `showTextDocument` and the next
+  // synchronous read, which would leave the test holding a reference to an
+  // unrelated editor and produce flaky failures.
+  const textEditor = await vscode.window.showTextDocument(doc, column, false);
 
   // Set EOL to LF for the tests to work even on Windows
-  await activeTextEditor.edit((editBuilder) => editBuilder.setEndOfLine(eol));
+  await textEditor.edit((editBuilder) => editBuilder.setEndOfLine(eol));
 
-  return activeTextEditor;
+  return textEditor;
 }
 
 export async function clearTextEditor(textEditor: TextEditor, initializeWith = ""): Promise<void> {
@@ -76,6 +78,18 @@ export function createEmulator(
 
 export function setEmptyCursors(textEditor: TextEditor, ...positions: Array<[number, number]>): void {
   textEditor.selections = positions.map((p) => new Selection(new Position(p[0], p[1]), new Position(p[0], p[1])));
+}
+
+// Select the whole text of `textEditor`. Use this instead of
+// `vscode.commands.executeCommand("editor.action.selectAll")` in tests because
+// the latter operates on `vscode.window.activeTextEditor`, which can drift
+// during the test (e.g. when an unrelated editor or output document grabs
+// focus) and produce flaky failures.
+export function selectAllText(textEditor: TextEditor): void {
+  const doc = textEditor.document;
+  const start = new Position(0, 0);
+  const end = doc.positionAt(doc.getText().length);
+  textEditor.selections = [new Selection(start, end)];
 }
 
 export async function cleanUpWorkspace(): Promise<void> {


### PR DESCRIPTION
## Summary

Tests in `kill-ring-yank.test.ts` and `kill-line.test.ts` relied on `vscode.window.activeTextEditor` continuing to point at the editor opened by `setupWorkspace`. When an unrelated editor or output document grabbed focus between setup and the test body, calls like `vscode.commands.executeCommand("editor.action.selectAll")` operated on the wrong editor and the assertions failed in different ways from run to run (issue #2675).

- Have `setupWorkspace` return the editor `showTextDocument` resolves to instead of re-reading `vscode.window.activeTextEditor`. The active editor can change between the resolution of `showTextDocument` and the next synchronous read.
- Add a `selectAllText(editor)` helper that sets the full-document selection on a specific editor reference, and use it in place of `editor.action.selectAll`.
- Restructure the parametrized "interrupting command" tests in both files to take a function that operates on the captured editor, so the interruption no longer depends on the active editor either.

Fixes #2675

## Test plan

- [ ] `npm run test-compile`
- [ ] `npm run check:eslint`
- [ ] `npm run check:prettier`
- [ ] `npm run test` (locally, repeated runs to confirm flakiness is gone)

https://claude.ai/code/session_012nSCbDQD2Eoi23hbV63nr5

---
_Generated by [Claude Code](https://claude.ai/code/session_012nSCbDQD2Eoi23hbV63nr5)_