### PR TITLE
Fix flaky kill-yank and newLine prefix-arg tests

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -4,7 +4,7 @@ import { EmacsCommand, type ITextEditorInterruptionHandler } from ".";
 import { makeParallel } from "./helpers/parallel";
 import { makeSelectionsEmpty } from "./helpers/selection";
 import { revealPrimaryActive } from "./helpers/reveal";
-import { delay } from "../utils";
+import { waitForDocumentToSettle } from "../utils";
 import { Logger } from "../logger";
 
 const logger = Logger.get("EditCommands");
@@ -244,9 +244,17 @@ export class NewLine extends EmacsCommand {
       return selection.active.isEqual(textEditor.document.lineAt(selection.active.line).range.end);
     });
 
+    // After `default:type "\n"` resolves, language-specific `OnEnter` rules
+    // (e.g. JSDoc ` * ` continuation) are applied as a follow-up
+    // `onDidChangeTextDocument` event rather than synchronously with the type
+    // command. Capturing the document state before that follow-up arrives
+    // produces wrong patterns and breaks the rebuilt insert below. Wait for
+    // the document to stop changing between and after the two `default:type`
+    // calls so the captures see the fully indented state.
     await vscode.commands.executeCommand<void>("default:type", { text: "\n" });
-    await delay(33); // Wait for code completion to finish. The value is ad-hoc.
+    await waitForDocumentToSettle(textEditor.document);
     await vscode.commands.executeCommand<void>("default:type", { text: "\n" });
+    await waitForDocumentToSettle(textEditor.document);
 
     // The first inserted lines can be affected by the second ones.
     // We need to capture its final content after the second insertion to achieve the desired result.

--- a/src/test/suite/commands/kill-yank/kill-line.test.ts
+++ b/src/test/suite/commands/kill-yank/kill-line.test.ts
@@ -10,6 +10,7 @@ import {
   assertCursorsEqual,
   cleanUpWorkspace,
   clearTextEditor,
+  selectAllText,
   setEmptyCursors,
   setupWorkspace,
   createEmulator,
@@ -150,18 +151,22 @@ abcdefghij
       );
     });
 
-    // Test kill appending is not enabled after cursorMove or some other commands
-    const otherInterruptingCommands = ["editor.action.selectAll"];
+    // Test kill appending is not enabled after cursorMove or some other commands.
+    // Interrupters are passed the target editor so that the test does not rely
+    // on `vscode.window.activeTextEditor`, which can drift during the test run.
+    const otherInterrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [
+      ["selectAllText", (editor) => selectAllText(editor)],
+    ];
 
-    const interruptingCommands: string[] = [...otherInterruptingCommands];
-    interruptingCommands.forEach((interruptingCommand) => {
-      test(`it does not appends killed text if another command (${interruptingCommand}) invoked`, async () => {
+    const interrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [...otherInterrupters];
+    interrupters.forEach(([interrupterLabel, interrupt]) => {
+      test(`it does not appends killed text if another command (${interrupterLabel}) invoked`, async () => {
         setEmptyCursors(activeTextEditor, [1, 5]);
 
         await emulator.runCommand("killLine"); // 2st line
         await emulator.runCommand("killLine"); // EOL of 2st
 
-        await vscode.commands.executeCommand(interruptingCommand); // Interrupt
+        interrupt(activeTextEditor); // Interrupt
 
         const endOfDoc = activeTextEditor.document.lineAt(activeTextEditor.document.lineCount - 1).range.end;
         const secondKillAtEndOfDoc = activeTextEditor.selections.every((selection) =>

--- a/src/test/suite/commands/kill-yank/kill-ring-yank.test.ts
+++ b/src/test/suite/commands/kill-yank/kill-ring-yank.test.ts
@@ -12,6 +12,7 @@ import {
   cleanUpWorkspace,
   clearTextEditor,
   delay,
+  selectAllText,
   setEmptyCursors,
   setupWorkspace,
   createEmulator,
@@ -36,15 +37,15 @@ suite("kill, yank, yank-pop", () => {
 
       // kill 3 times with different texts
       await clearTextEditor(activeTextEditor, "Lorem ipsum");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       await clearTextEditor(activeTextEditor, "dolor sit amet,\nconsectetur adipiscing elit,");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       await clearTextEditor(activeTextEditor, "sed do eiusmod tempor\nincididunt ut labore et\ndolore magna aliqua.");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Initialize with non-empty text
@@ -138,7 +139,7 @@ ABCDEFGHIJ`,
 
       // Kill first
       await clearTextEditor(activeTextEditor, "Lorem ipsum");
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Then, copy to clipboard
@@ -206,23 +207,27 @@ ABCDEFGHIJ`,
       );
     });
 
-    // Test yankPop is not executed after cursorMove or some other commands
-    const otherInterruptingCommands = ["editor.action.selectAll"];
-    const interruptingCommands: string[] = [...otherInterruptingCommands];
+    // Test yankPop is not executed after cursorMove or some other commands.
+    // Interrupters are passed the target editor so that the test does not rely
+    // on `vscode.window.activeTextEditor`, which can drift during the test run.
+    const otherInterrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [
+      ["selectAllText", (editor) => selectAllText(editor)],
+    ];
+    const interrupters: Array<[string, (editor: vscode.TextEditor) => void]> = [...otherInterrupters];
 
-    interruptingCommands.forEach((interruptingCommand) => {
-      test(`yankPop works as browse-kill-ring if ${interruptingCommand} is executed after previous yank`, async () => {
+    interrupters.forEach(([interrupterLabel, interrupt]) => {
+      test(`yankPop works as browse-kill-ring if ${interrupterLabel} is executed after previous yank`, async () => {
         const killRing = new KillRing(3);
         const browseStub = sinon.stub(killRing, "browse").resolves(new ClipboardTextKillRingEntity("foo"));
         const emulator = createEmulator(activeTextEditor, killRing);
 
         // Kill texts
         await clearTextEditor(activeTextEditor, "FOO");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         await clearTextEditor(activeTextEditor, "BAR");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         // Initialize with non-empty text
@@ -243,8 +248,8 @@ abcdeBARfghij
 ABCDEFGHIJ`,
         );
 
-        // Interruption command invoked
-        await vscode.commands.executeCommand(interruptingCommand);
+        // Interruption invoked
+        interrupt(activeTextEditor);
 
         // yankPop works as browse-kill-ring
         await emulator.runCommand("yankPop");
@@ -257,18 +262,18 @@ ABCDEFGHIJ`,
         //         );
       });
 
-      test(`yankPop works as browse-kill-ring if ${interruptingCommand} is executed after previous yankPop`, async () => {
+      test(`yankPop works as browse-kill-ring if ${interrupterLabel} is executed after previous yankPop`, async () => {
         const killRing = new KillRing(3);
         const browseStub = sinon.stub(killRing, "browse").resolves(new ClipboardTextKillRingEntity("foo"));
         const emulator = createEmulator(activeTextEditor, killRing);
 
         // Kill texts
         await clearTextEditor(activeTextEditor, "FOO");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         await clearTextEditor(activeTextEditor, "BAR");
-        await vscode.commands.executeCommand("editor.action.selectAll");
+        selectAllText(activeTextEditor);
         await emulator.runCommand("killRegion");
 
         // Initialize with non-empty text
@@ -298,8 +303,8 @@ abcdeFOOfghij
 ABCDEFGHIJ`,
         );
 
-        // Interruption command invoked
-        await vscode.commands.executeCommand(interruptingCommand);
+        // Interruption invoked
+        interrupt(activeTextEditor);
 
         // yankPop works as browse-kill-ring
         await emulator.runCommand("yankPop");
@@ -350,11 +355,11 @@ ABCDEFGHIJ`,
         test(`yankPop works as browse-kill-ring if ${label} is executed after previous yank`, async () => {
           // Kill texts
           await clearTextEditor(activeTextEditor, "FOO");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           await clearTextEditor(activeTextEditor, "BAR");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           // Initialize with non-empty text
@@ -394,11 +399,11 @@ ABCDEFGHIJ`,
         test(`yankPop works as browse-kill-ring if ${label} is executed after previous yankPop`, async () => {
           // Kill texts
           await clearTextEditor(activeTextEditor, "FOO");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           await clearTextEditor(activeTextEditor, "BAR");
-          await vscode.commands.executeCommand("editor.action.selectAll");
+          selectAllText(activeTextEditor);
           await emulator.runCommand("killRegion");
 
           // Initialize with non-empty text
@@ -461,11 +466,11 @@ ABCDEFGHIJ`,
       const emulator = createEmulator(activeTextEditor, killRing);
 
       // Kill text
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Kill empty text
-      await vscode.commands.executeCommand("editor.action.selectAll");
+      selectAllText(activeTextEditor);
       await emulator.runCommand("killRegion");
 
       // Now the text is empty
@@ -564,11 +569,11 @@ suite("yank pop with auto-indent", () => {
 
     // Kill texts
     await clearTextEditor(activeTextEditor, "foo"); // No indent
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor);
     await emulator.runCommand("killRegion");
 
     await clearTextEditor(activeTextEditor, "bar"); // No indent
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor);
     await emulator.runCommand("killRegion");
 
     // Initialize with parentheses, that triggers auto-indent to inner text
@@ -785,11 +790,11 @@ suite("With not only single text editor", () => {
 
     // Kill texts from one text editor
     await clearTextEditor(activeTextEditor0, "FOO");
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor0);
     await emulator0.runCommand("killRegion");
 
     await clearTextEditor(activeTextEditor0, "BAR");
-    await vscode.commands.executeCommand("editor.action.selectAll");
+    selectAllText(activeTextEditor0);
     await emulator0.runCommand("killRegion");
 
     const activeTextEditor1 = await setupWorkspace("");

--- a/src/test/suite/utils.ts
+++ b/src/test/suite/utils.ts
@@ -26,15 +26,17 @@ export async function setupWorkspace(
     language,
   });
 
-  await vscode.window.showTextDocument(doc, column, false);
-
-  const activeTextEditor = vscode.window.activeTextEditor;
-  assert.ok(activeTextEditor);
+  // Return the `TextEditor` that `showTextDocument` resolves to instead of
+  // reading `vscode.window.activeTextEditor` after the call. The active editor
+  // can change between the resolution of `showTextDocument` and the next
+  // synchronous read, which would leave the test holding a reference to an
+  // unrelated editor and produce flaky failures.
+  const textEditor = await vscode.window.showTextDocument(doc, column, false);
 
   // Set EOL to LF for the tests to work even on Windows
-  await activeTextEditor.edit((editBuilder) => editBuilder.setEndOfLine(eol));
+  await textEditor.edit((editBuilder) => editBuilder.setEndOfLine(eol));
 
-  return activeTextEditor;
+  return textEditor;
 }
 
 export async function clearTextEditor(textEditor: TextEditor, initializeWith = ""): Promise<void> {
@@ -76,6 +78,18 @@ export function createEmulator(
 
 export function setEmptyCursors(textEditor: TextEditor, ...positions: Array<[number, number]>): void {
   textEditor.selections = positions.map((p) => new Selection(new Position(p[0], p[1]), new Position(p[0], p[1])));
+}
+
+// Select the whole text of `textEditor`. Use this instead of
+// `vscode.commands.executeCommand("editor.action.selectAll")` in tests because
+// the latter operates on `vscode.window.activeTextEditor`, which can drift
+// during the test (e.g. when an unrelated editor or output document grabs
+// focus) and produce flaky failures.
+export function selectAllText(textEditor: TextEditor): void {
+  const doc = textEditor.document;
+  const start = new Position(0, 0);
+  const end = doc.positionAt(doc.getText().length);
+  textEditor.selections = [new Selection(start, end)];
 }
 
 export async function cleanUpWorkspace(): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { Position, Range, TextEditor } from "vscode";
+import * as vscode from "vscode";
+import { Position, Range, TextDocument, TextEditor } from "vscode";
 
 export function equalPositions(positions1: readonly Position[], positions2: readonly Position[]): boolean {
   if (positions1.length !== positions2.length) {
@@ -9,6 +10,34 @@ export function equalPositions(positions1: readonly Position[], positions2: read
 
 export function delay(time?: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, time));
+}
+
+// Wait until `document` has not emitted an `onDidChangeTextDocument` event for
+// `settleMs`, or until `timeoutMs` elapses, whichever comes first. Used to
+// wait for asynchronous editor follow-ups (e.g. `OnEnter` rule auto-indent)
+// that arrive after the triggering command's promise has already resolved.
+export async function waitForDocumentToSettle(
+  document: TextDocument,
+  { settleMs = 100, timeoutMs = 1000 }: { settleMs?: number; timeoutMs?: number } = {},
+): Promise<void> {
+  let lastChangeAt = Date.now();
+  const disposable = vscode.workspace.onDidChangeTextDocument((event) => {
+    if (event.document === document) {
+      lastChangeAt = Date.now();
+    }
+  });
+  try {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const sinceLastChange = Date.now() - lastChangeAt;
+      if (sinceLastChange >= settleMs) {
+        return;
+      }
+      await delay(Math.min(settleMs - sinceLastChange, 20));
+    }
+  } finally {
+    disposable.dispose();
+  }
 }
 
 // HACK: Currently there is no official type-safe way to handle


### PR DESCRIPTION
## Summary

Two independent fixes for the test flakiness tracked under #2675 that together get macOS CI green again.

### 1. Kill-yank tests vs. active-editor drift (the originally reported flake)

`kill-ring-yank.test.ts` and `kill-line.test.ts` called `executeCommand("editor.action.selectAll")` and trusted `vscode.window.activeTextEditor` to keep pointing at the editor `setupWorkspace` opened. When another editor or output document grabbed focus between setup and the test body, those commands operated on the wrong editor, producing the cursor-position assertion failures from the issue report.

- `setupWorkspace` now returns the editor that `showTextDocument` resolves to instead of re-reading `vscode.window.activeTextEditor`.
- New `selectAllText(editor)` helper sets the full-document selection on a specific editor reference, replacing `executeCommand("editor.action.selectAll")` throughout these suites.
- The parametrized "interrupting command" tests now take an interrupter `(editor) => void` instead of a command id, so the interruption no longer depends on the active editor either.

### 2. `NewLine.run` capture race when OnEnter rules are slow

`NewLine.run` with `prefixArgument > 1` fires `default:type "\n"` twice, then captures the auto-indented line contents to rebuild a single edit. `default:type` resolves *before* the language-specific `OnEnter` rule (e.g. JSDoc ` * ` continuation) applies — that follow-up arrives as a separate `onDidChangeTextDocument` event. On macOS CI the JS/TS language service does not always deliver it within the ad-hoc 33 ms delay, and there was no wait at all after the second type, so the capture saw a missing ` * ` prefix and the rebuilt insert ended up with a blank continuation line:

    + '/**\n * \n * \n * \n \n */'
    - '/**\n * \n * \n * \n * \n */'

This was the lingering macOS failure in #2897 even after its warm-up tweak. The fix:

- New `waitForDocumentToSettle(document, { settleMs, timeoutMs })` in `src/utils.ts` — subscribes to `onDidChangeTextDocument` and returns once the document has been quiet for `settleMs` (or `timeoutMs` elapses).
- `NewLine.run` uses it after **both** `default:type "\n"` calls in place of the previous `delay(33)`, so the captured patterns reflect the fully indented state regardless of how slow the language service is on a given host.

The benefit accrues to end users too: `C-u RET` in a JSDoc context is less likely to drop an indent prefix on slower machines.

Refs #2675. Supersedes #2897.

## Test plan

- [ ] `npm run check:eslint` (passes locally)
- [ ] `npm run check:prettier` (passes locally)
- [ ] `npm run test-compile` (passes locally)
- [ ] CI: `test (macos-latest, native)` — the previously failing `newLine ... with auto-indentation with a prefix argument ... typescript` should now pass
- [ ] CI: `test (ubuntu-latest, native)`, `test (windows-latest, native)`, `test (ubuntu-latest, web)`
- [ ] Manual: in a TypeScript file, place the cursor inside `/** | */`, press `C-u RET`, and verify all four continuation lines render as ` * `.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of newline insertion by ensuring proper document settlement between operations, reducing timing-related issues.

* **Tests**
  * Enhanced test infrastructure to reduce flakiness by using direct editor operations instead of command-based approaches and ensuring proper editor context handling in interrupt-based tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/vscode-emacs-mcx/pull/2898)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->