### PR TITLE
Auto-merge patch and minor Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+# `pull_request_target` is what makes this work at all: the `GITHUB_TOKEN` handed to
+# Dependabot's `pull_request` events is read-only, so a `pull_request`-triggered job
+# cannot enable auto-merge. This workflow never checks out or runs the PR's code, so
+# the write-capable base-branch context stays out of the branch's reach.
+on:
+  pull_request_target:
+    branches: ["main"]
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      # GitHub holds the merge until every required check on `main` passes, so a red
+      # test run leaves the PR sitting open rather than landing broken.
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,9 +1,10 @@
 name: Dependabot auto-merge
 
-# `pull_request_target` is what makes this work at all: the `GITHUB_TOKEN` handed to
-# Dependabot's `pull_request` events is read-only, so a `pull_request`-triggered job
-# cannot enable auto-merge. This workflow never checks out or runs the PR's code, so
-# the write-capable base-branch context stays out of the branch's reach.
+# Dependabot's `pull_request` events run with a read-only `GITHUB_TOKEN` that the
+# `permissions` key cannot raise, so enabling auto-merge needs `pull_request_target`
+# and its base-branch context. Nothing here checks out or executes the PR's code,
+# which is what keeps that write-capable context out of the branch's reach.
+# Ref: https://github.com/dependabot/fetch-metadata#enabling-auto-merge
 on:
   pull_request_target:
     branches: ["main"]
@@ -22,10 +23,14 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      # GitHub holds the merge until every required check on `main` passes, so a red
-      # test run leaves the PR sitting open rather than landing broken.
+      # Match the update types to merge rather than the ones to skip. Dependabot omits
+      # `update-type` from the commit trailer on multi-dependency and transitive-only
+      # PRs, and those have carried majors here before, so an unknown type has to fall
+      # through to a manual merge instead of being treated as non-major.
       - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Dependabot opens several PRs a day in this repo, and each one needs a manual merge click after CI goes green. This workflow turns on GitHub's auto-merge for patch and minor bumps in both the npm and github-actions ecosystems, so they land on their own once the required checks on `main` pass. Major bumps stay manual, as do multi-dependency and transitive security PRs, whose Dependabot metadata carries no update type at all.

Three repository settings this depends on: "Allow auto-merge" and "Allow squash merging" must be on in Settings, and `main`'s protection needs required status checks, since auto-merge with no required checks merges immediately.

One consequence worth knowing about: a merge performed under `GITHUB_TOKEN` does not trigger `push`-triggered workflows, so Changesets will not re-run on `main` for an auto-merged PR. Dependabot PRs carry no changeset, and the next ordinary push picks the release PR back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDhRix7AdzNbNpGJ25akYP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDhRix7AdzNbNpGJ25akYP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated handling for eligible Dependabot updates targeting the main branch.
  * Patch and minor updates can now be queued for automatic squash merging.
  * Major, unknown, or otherwise ineligible updates remain available for manual review and merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->